### PR TITLE
Use shell to execute evaluation commands

### DIFF
--- a/src/main/kotlin/de/code_freak/codefreak/service/ContainerBuilder.kt
+++ b/src/main/kotlin/de/code_freak/codefreak/service/ContainerBuilder.kt
@@ -11,7 +11,10 @@ class ContainerBuilder {
   var name: String? = null
   fun hostConfig(modify: HostConfig.Builder.() -> Unit) = hostConfigBuilder.modify()
   fun containerConfig(modify: ContainerConfig.Builder.() -> Unit) = containerConfigBuilder.modify()
-  fun doNothingAndKeepAlive() = containerConfig { entrypoint("tail", "-f", "/dev/null") }
+  fun shellScript(script: String) = containerConfig {
+    entrypoint("sh", "-c")
+    cmd(script)
+  }
 
   fun build(): ContainerConfig = containerConfigBuilder
       .hostConfig(hostConfigBuilder.build())

--- a/src/main/kotlin/de/code_freak/codefreak/service/ExecResult.kt
+++ b/src/main/kotlin/de/code_freak/codefreak/service/ExecResult.kt
@@ -1,5 +1,8 @@
 package de.code_freak.codefreak.service
 
-data class ExecResult(val output: String, val exitCode: Long) {
-  private constructor() : this("", 0)
+data class ExecResult(val exitCode: Long, val stdout: String, val stderr: String = "") {
+  constructor() : this("", -1)
+  constructor(output: String, exitCode: Long): this(exitCode, output)
+  val output = stdout
+  val success = exitCode == 0L
 }

--- a/src/main/kotlin/de/code_freak/codefreak/service/evaluation/runner/JUnitRunner.kt
+++ b/src/main/kotlin/de/code_freak/codefreak/service/evaluation/runner/JUnitRunner.kt
@@ -2,6 +2,7 @@ package de.code_freak.codefreak.service.evaluation.runner
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import de.code_freak.codefreak.entity.Answer
+import de.code_freak.codefreak.service.ExecResult
 import de.code_freak.codefreak.util.TarUtil
 import de.code_freak.codefreak.util.withTrailingSlash
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
@@ -15,12 +16,12 @@ import java.io.ByteArrayOutputStream
 @Component
 class JUnitRunner : CommandLineRunner() {
 
-  private class Results(val executions: List<Execution>, val xmlReports: List<ByteArray>) {
-    private constructor() : this(emptyList(), emptyList())
+  private class Results(val result: ExecResult, val xmlReports: List<ByteArray>) {
+    private constructor() : this(ExecResult(), emptyList())
   }
 
-  private class RenderResults(val executions: List<Execution>, val testSuites: List<JUnitTestSuite>) {
-    private constructor() : this(emptyList(), emptyList())
+  private class RenderResults(val result: ExecResult, val testSuites: List<JUnitTestSuite>) {
+    private constructor() : this(ExecResult(), emptyList())
   }
 
   private data class Summary(val error: Boolean, val total: Int, val passed: Int)
@@ -41,7 +42,7 @@ class JUnitRunner : CommandLineRunner() {
         "commands" to listOf("gradle testClasses", "gradle test")
     )
     val xmlReports = mutableListOf<ByteArray>()
-    val executions = super.executeCommands(answer, defaultOptions + options) { files ->
+    val execution = super.executeCommands(answer, defaultOptions + options) { files ->
       val tar = TarArchiveInputStream(files)
       generateSequence { tar.nextTarEntry }.forEach {
         if (it.isFile && TarUtil.normalizeEntryName(it.name).matches(resultsPattern)) {
@@ -51,18 +52,18 @@ class JUnitRunner : CommandLineRunner() {
         }
       }
     }
-    return mapper.writeValueAsString(Results(executions, xmlReports))
+    return mapper.writeValueAsString(Results(execution.result, xmlReports))
   }
 
   override fun parseResultContent(content: ByteArray): Any {
     val results = mapper.readValue(content, Results::class.java)
     val testSuites = results.xmlReports.map { JUnitMarshalling.unmarshalTestSuite(ByteArrayInputStream(it)) }
-    return RenderResults(results.executions, testSuites)
+    return RenderResults(results.result, testSuites)
   }
 
   override fun getSummary(content: Any): Any {
     return (content as RenderResults).let { results ->
-      val error = results.executions.any { it.result.exitCode == -1L }
+      val error = results.testSuites.isEmpty()
       val passed = results.testSuites.map { it.tests - it.skipped - it.failures - it.errors }.sum()
       val total = results.testSuites.map { it.tests - it.skipped }.sum()
       Summary(error, total, passed)

--- a/src/main/resources/templates/evaluation-summary/commandline.html
+++ b/src/main/resources/templates/evaluation-summary/commandline.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
-<span th:title="|Command line: ${content.passed}/${content.total} commands executed successfully|" data-toggle="tooltip">
-  <th:block th:switch="${content.passed}">
-    <i th:case="${content.total}" class="fas fa-check-circle text-success"></i>
+<span>
+  <th:block th:switch="${content.success}">
+    <i th:case="${true}" class="fas fa-check-circle text-success"></i>
     <i th:case="*" class="fas fa-times-circle text-danger"></i>
   </th:block>
-  <th:block th:text="|${content.passed}/${content.total}|"></th:block>
 </span>
 </body>
 </html>

--- a/src/main/resources/templates/evaluation/commandline.html
+++ b/src/main/resources/templates/evaluation/commandline.html
@@ -2,16 +2,16 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
 <h3 class="card-title">Command Line</h3>
-<div class="mb-3" th:each="execution : ${content}">
-  <h4>
-    <th:block th:switch="${execution.result.exitCode}">
-      <span th:case="0" class="badge badge-success">Success</span>
-      <span th:case="-1" class="badge badge-info">Skipped</span>
-      <span th:case="*" class="badge badge-danger">Failure</span>
-    </th:block>
-    <code th:text="${execution.command}"></code>
-  </h4>
-  <pre th:text="${execution.result.output}"></pre>
+<div class="lead" th:switch="${content.result.success}">
+  <span th:case="true" class="badge badge-success">Success</span>
+  <span th:case="*" class="badge badge-danger">Failure</span>
 </div>
+<h4>Command</h4>
+<code><pre th:text="${content.command}"></pre></code>
+<h4>Output</h4>
+<pre th:switch="${content.result.success}">
+<th:block th:case="true" th:text="${content.result.stdout}"/>
+<th:block th:case="*" th:text="${content.result.stderr}"/>
+</pre>
 </body>
 </html>

--- a/src/main/resources/templates/evaluation/error.html
+++ b/src/main/resources/templates/evaluation/error.html
@@ -2,6 +2,6 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
 <h3 class="card-title">Error for runner '<span th:text="${result.runnerName}"></span>'</h3>
-<div class="alert alert-danger" th:text="${content}"></div>
+<div class="alert alert-danger"><pre th:text="${content}"></pre></div>
 </body>
 </html>

--- a/src/main/resources/templates/evaluation/junit.html
+++ b/src/main/resources/templates/evaluation/junit.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
 <h3 class="card-title">Unit Tests</h3>
-<th:block th:with="error = ${content.executions.?[result.exitCode == -1].size() > 0}">
+<th:block th:with="error = ${content.testSuites.isEmpty()}">
   <div th:unless="${error}" class="mb-3" th:each="testSuite : ${content.testSuites}">
     <h4>
       <span th:text="${testSuite.name}"></span>
@@ -28,7 +28,7 @@
   </div>
   <th:block th:if="${error}">
     <div class="alert alert-danger">Error while executing tests!</div>
-    <pre th:text="${content.executions.?[result.exitCode > 0].get(0).result.output}"></pre>
+    <pre th:text="${content.result.stderr}"></pre>
   </th:block>
 </th:block>
 </body>

--- a/src/test/kotlin/de/code_freak/codefreak/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/de/code_freak/codefreak/service/ContainerServiceTest.kt
@@ -1,5 +1,6 @@
 package de.code_freak.codefreak.service
 
+import com.nhaarman.mockitokotlin2.eq
 import com.spotify.docker.client.DockerClient
 import com.spotify.docker.client.DockerClient.ListContainersParam
 import de.code_freak.codefreak.SpringTest
@@ -9,23 +10,22 @@ import de.code_freak.codefreak.util.TarUtil
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.greaterThan
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
+import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.core.io.ClassPathResource
 import java.io.ByteArrayOutputStream
 import java.util.UUID
-import com.nhaarman.mockitokotlin2.eq
-import org.hamcrest.Matchers.greaterThan
-import org.junit.Ignore
-import org.mockito.Mockito
-import org.springframework.boot.test.mock.mockito.MockBean
 
 internal class ContainerServiceTest : SpringTest() {
 


### PR DESCRIPTION
* [x] Run evaluation commands using shell and start/attach instead of keep-alive/exec (#175)
* [x] Split stdout and stderr (#195)
* [ ] Create combined output of stdout and stderr (should use stream-functionality of `attach()` and separate thread)
* [ ] Detect bash-compatible shell (see https://gitlab.com/munnerz/gitlab-ci-multi-runner/blob/master/shells/bash.go#L16)
* [ ] Expose some environment variables about current evaluation (e.g. user, task, ...)
...