### PR TITLE
Refactor frontend version display

### DIFF
--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -1,7 +1,11 @@
+const { DefinePlugin } = require('webpack')
 const CracoAntDesignPlugin = require('craco-antd')
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
 const rawLoader = require('craco-raw-loader')
 const CopyPlugin = require('copy-webpack-plugin')
+const GitRevisionPlugin = require('git-revision-webpack-plugin')
+
+const gitRevisionPlugin = new GitRevisionPlugin()
 
 module.exports = {
   plugins: [
@@ -17,7 +21,13 @@ module.exports = {
           to: 'fonts',
           flatten: true
         }
-      ])
+      ]),
+      new GitRevisionPlugin(),
+      new DefinePlugin({
+        'process.env.BUILD_YEAR': JSON.stringify(new Date().getFullYear()),
+        'process.env.BUILD_VERSION': JSON.stringify(gitRevisionPlugin.version()),
+        'process.env.BUILD_HASH': JSON.stringify(gitRevisionPlugin.commithash())
+      })
     ]
   }
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1864,11 +1864,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
       "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA=="
     },
-    "@types/preval.macro": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/preval.macro/-/preval.macro-3.0.0.tgz",
-      "integrity": "sha512-mm7qx+Aj9bhMcK9Y3UHNy6zCQneRj+GBFlCi+cxtx66iLU4yarOupVLrFadlG+Cd4TEsdo4og0REhzUQQ7m3fg=="
-    },
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -2970,26 +2965,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.4.tgz",
       "integrity": "sha512-S6d+tEzc5Af1tKIMbsf2QirCcPdQ+mKUCY2H1nJj1DyA1ShwpsoxEOAwbWsG5gcXNV/olpvQd9vrUWRx4bnhpw=="
     },
-    "babel-plugin-preval": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-preval/-/babel-plugin-preval-4.0.0.tgz",
-      "integrity": "sha512-fZI/4cYneinlj2k/FsXw0/lTWSC5KKoepUueS1g25Gb5vx3GrRyaVwxWCshYqx11GEU4mZnbbFhee8vpquFS2w==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "babel-plugin-macros": "^2.6.1",
-        "require-from-string": "^2.0.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-          "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        }
-      }
-    },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
@@ -3761,7 +3736,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3779,11 +3755,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3796,15 +3774,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3907,7 +3888,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3917,6 +3899,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3929,17 +3912,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3956,6 +3942,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -4028,7 +4015,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -4038,6 +4026,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4113,7 +4102,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -4143,6 +4133,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4160,6 +4151,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -4198,11 +4190,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -7169,6 +7163,12 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "git-revision-webpack-plugin": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/git-revision-webpack-plugin/-/git-revision-webpack-plugin-3.0.6.tgz",
+      "integrity": "sha512-vW/9dBahGbpKPcccy3xKkHgdWoH/cAPPc3lQw+3edl7b4j29JfNGVrja0a1d8ZoRe4nTN8GCPrF9aBErDnzx5Q==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -12637,14 +12637,6 @@
         "react-is": "^16.8.4"
       }
     },
-    "preval.macro": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/preval.macro/-/preval.macro-4.0.0.tgz",
-      "integrity": "sha512-sJJnE71X+MPr64CVD2AurmUj4JEDqbudYbStav3L9Xjcqm4AR0ymMm6sugw1mUmfI/7gw4JWA4JXo/k6w34crw==",
-      "requires": {
-        "babel-plugin-preval": "^4.0.0"
-      }
-    },
     "prismjs": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.19.0.tgz",
@@ -14595,11 +14587,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-main-filename": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,6 @@
     "@types/jest": "24.0.20",
     "@types/loadable__component": "^5.10.0",
     "@types/node": "12.11.7",
-    "@types/preval.macro": "^3.0.0",
     "@types/react": "16.9.11",
     "@types/react-dom": "16.9.3",
     "@types/react-helmet": "^5.0.14",
@@ -44,7 +43,6 @@
     "monaco-editor-webpack-plugin": "^1.9.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
-    "preval.macro": "^4.0.0",
     "react": "^16.11.0",
     "react-asciidoc": "^0.1.0",
     "react-dom": "^16.11.0",
@@ -63,7 +61,10 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-react": "^4.1.0",
     "typescript": "3.6.4",
-    "use-persisted-state": "^0.3.0"
+    "use-persisted-state": "^0.3.0",
+    "copy-webpack-plugin": "^5.1.1",
+    "craco-raw-loader": "^1.0.1",
+    "git-revision-webpack-plugin": "^3.0.6"
   },
   "scripts": {
     "start": "craco start",
@@ -94,9 +95,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "copy-webpack-plugin": "^5.1.1",
-    "craco-raw-loader": "^1.0.1"
   }
 }

--- a/client/src/components/AppFooter.tsx
+++ b/client/src/components/AppFooter.tsx
@@ -1,14 +1,14 @@
-import { Layout, Tooltip } from 'antd'
-import preval from 'preval.macro'
+import { Layout } from 'antd'
 import React from 'react'
 import './AppFooter.less'
 
 const repoUrl = 'https://github.com/codefreak/codefreak'
 
 const AppFooter: React.FC = () => {
-  const buildYear = preval`module.exports = new Date().getFullYear();`
-  const buildVersion = preval`module.exports = (process.env.GIT_TAG ? 'v' + process.env.GIT_TAG : undefined) || "[dev]"`
-  const buildHash = process.env.GIT_COMMIT
+  const buildYear = process.env.BUILD_YEAR
+  // version and hash are exposed by git-revision-webpack-plugin
+  const buildVersion = process.env.BUILD_VERSION || 'dev'
+  const buildHash = process.env.BUILD_HASH
   const buildVersionLink = buildHash
     ? `${repoUrl}/commit/${buildHash}`
     : repoUrl
@@ -16,11 +16,9 @@ const AppFooter: React.FC = () => {
   return (
     <Layout.Footer>
       powered by Code FREAK{' '}
-      <Tooltip title={buildHash}>
-        <a href={buildVersionLink} target="_blank" rel="noopener noreferrer">
-          {buildVersion}
-        </a>
-      </Tooltip>
+      <a href={buildVersionLink} target="_blank" rel="noopener noreferrer">
+        v{buildVersion}
+      </a>
       <br />© 2019-{buildYear}{' '}
       <a href="https://codefreak.org" target="_blank" rel="noopener noreferrer">
         codefreak.org


### PR DESCRIPTION
* Always show a version number (also during dev using "git describe --always")
* Replace preval with webpacks DefinePlugin & webpack version plugin
* Remove hash tooltip

Dev Version info:
![image](https://user-images.githubusercontent.com/2829004/82651804-f1533180-9c1c-11ea-954f-f64f1309fc47.png)

Tagged Version info:
![image](https://user-images.githubusercontent.com/2829004/82651924-1ba4ef00-9c1d-11ea-9f6e-67f8997ae4f9.png)
