### PR TITLE
Move re-evaluation button for teachers into edit details frame

### DIFF
--- a/client/src/components/StartSubmissionEvaluationButton.tsx
+++ b/client/src/components/StartSubmissionEvaluationButton.tsx
@@ -1,0 +1,50 @@
+import { Button, message } from 'antd'
+import { ButtonProps } from 'antd/es/button'
+import React, { useEffect } from 'react'
+import { useStartAssignmentEvaluationMutation } from '../generated/graphql'
+
+interface StartSubmissionEvaluationButton extends ButtonProps {
+  assignmentId: string
+  invalidateAll?: boolean
+  invalidateTask?: string
+}
+
+const StartSubmissionEvaluationButton: React.FC<StartSubmissionEvaluationButton> = ({
+  assignmentId,
+  invalidateAll,
+  invalidateTask,
+  ...buttonProps
+}) => {
+  const [
+    startAssignmentEvaluation,
+    assignmentEvaluationResult
+  ] = useStartAssignmentEvaluationMutation()
+
+  const evaluateAll = () =>
+    startAssignmentEvaluation({
+      variables: { assignmentId, invalidateTask, invalidateAll }
+    })
+
+  useEffect(() => {
+    if (assignmentEvaluationResult.data) {
+      const {
+        startAssignmentEvaluation: queuedEvaluations
+      } = assignmentEvaluationResult.data
+      if (queuedEvaluations.length) {
+        message.success(`Queued ${queuedEvaluations.length} evaluation(s)`)
+      } else {
+        message.info(`No new evaluations queued`)
+      }
+    }
+  }, [assignmentEvaluationResult])
+
+  return (
+    <Button
+      {...buttonProps}
+      loading={assignmentEvaluationResult.loading}
+      onClick={evaluateAll}
+    />
+  )
+}
+
+export default StartSubmissionEvaluationButton

--- a/client/src/components/SubmissionsTable.tsx
+++ b/client/src/components/SubmissionsTable.tsx
@@ -1,22 +1,10 @@
-import {
-  Button,
-  Col,
-  Dropdown,
-  Icon,
-  Input,
-  Menu,
-  message,
-  Row,
-  Table,
-  Tooltip
-} from 'antd'
-import React, { ChangeEvent, useEffect, useState } from 'react'
+import { Button, Col, Icon, Input, Row, Table, Tooltip } from 'antd'
+import React, { ChangeEvent, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
   EvaluationStepResult,
   GetAssignmentWithSubmissionsQueryResult,
-  PendingEvaluationStatus,
-  useStartAssignmentEvaluationMutation
+  PendingEvaluationStatus
 } from '../generated/graphql'
 import useAnswerEvaluation from '../hooks/useAnswerEvaluation'
 import { getEntityPath } from '../services/entity-path'
@@ -75,34 +63,6 @@ const SubmissionsTable: React.FC<{ assignment: Assignment }> = ({
     setSearchCriteria(e.target.value)
   }
 
-  const [
-    startAssignmentEvaluation,
-    assignmentEvaluationResult
-  ] = useStartAssignmentEvaluationMutation()
-
-  const evaluateAll = () =>
-    startAssignmentEvaluation({
-      variables: { assignmentId: assignment.id }
-    })
-  const forceEvaluateAll = () =>
-    startAssignmentEvaluation({
-      variables: { force: true, assignmentId: assignment.id }
-    })
-
-  // show message with number of queued evaluations
-  useEffect(() => {
-    if (assignmentEvaluationResult.data) {
-      const {
-        startAssignmentEvaluation: queuedEvaluations
-      } = assignmentEvaluationResult.data
-      if (queuedEvaluations.length) {
-        message.success(`Queued ${queuedEvaluations.length} evaluation(s)`)
-      } else {
-        message.info(`No new evaluations queued`)
-      }
-    }
-  }, [assignmentEvaluationResult])
-
   const titleFunc = () => {
     return (
       <Row>
@@ -115,28 +75,6 @@ const SubmissionsTable: React.FC<{ assignment: Assignment }> = ({
           />
         </Col>
         <Col span={18} style={{ textAlign: 'right' }}>
-          <Button.Group>
-            <Button
-              loading={assignmentEvaluationResult.loading}
-              onClick={evaluateAll}
-              type="default"
-              icon="reload"
-            >
-              Evaluate all submissions
-            </Button>
-            <Dropdown
-              placement="bottomRight"
-              overlay={
-                <Menu>
-                  <Menu.Item key="force" onClick={forceEvaluateAll}>
-                    Force (re-)evaluation of all submissions
-                  </Menu.Item>
-                </Menu>
-              }
-            >
-              <Button icon="more" />
-            </Dropdown>
-          </Button.Group>
           <Button
             type="default"
             href={`${assignment.submissionsDownloadUrl}.csv`}
@@ -145,7 +83,7 @@ const SubmissionsTable: React.FC<{ assignment: Assignment }> = ({
             Download results as .csv
           </Button>
           <ArchiveDownload url={assignment.submissionsDownloadUrl}>
-            Download all submissions…
+            Download files of all submissions…
           </ArchiveDownload>
         </Col>
       </Row>

--- a/client/src/graphql/mutations/evaluation.graphql
+++ b/client/src/graphql/mutations/evaluation.graphql
@@ -6,9 +6,14 @@ mutation StartEvaluation($answerId: ID!) {
 
 mutation StartAssignmentEvaluation(
   $assignmentId: ID!
-  $force: Boolean = false
+  $invalidateAll: Boolean
+  $invalidateTask: ID
 ) {
-  startAssignmentEvaluation(assignmentId: $assignmentId, force: $force) {
+  startAssignmentEvaluation(
+    assignmentId: $assignmentId
+    invalidateAll: $invalidateAll
+    invalidateTask: $invalidateTask
+  ) {
     answer {
       id
     }

--- a/client/src/pages/task/TaskDetailsPage.tsx
+++ b/client/src/pages/task/TaskDetailsPage.tsx
@@ -19,6 +19,7 @@ import { Link } from 'react-router-dom'
 import AsyncPlaceholder from '../../components/AsyncContainer'
 import EditableMarkdown from '../../components/EditableMarkdown'
 import JsonSchemaEditButton from '../../components/JsonSchemaEditButton'
+import StartSubmissionEvaluationButton from '../../components/StartSubmissionEvaluationButton'
 import useIdParam from '../../hooks/useIdParam'
 import useSubPath from '../../hooks/useSubPath'
 import {
@@ -157,14 +158,23 @@ const TaskDetailsPage: React.FC<{ editable: boolean }> = ({ editable }) => {
               message="Warning"
               description={
                 <>
-                  The assignment is already open. If you make changes to files,
-                  they do not affect students that already started to work on
-                  this task. Only students that start the task after the change
-                  will get the updated files. Hidden and protected files are
-                  updated for everyone but only in new evaluations. Past
-                  evaluations are not affected.{' '}
-                  <Checkbox onChange={onSureToEditFilesChange} /> I understand
-                  this and want to do it anyway
+                  <p>
+                    The assignment is already open. If you make changes to
+                    files, they do not affect students that already started to
+                    work on this task. Only students that start the task after
+                    the change will get the updated files. Hidden and protected
+                    files are updated for everyone but only in new evaluations.
+                    Past evaluations are not affected.
+                  </p>
+                  <p>
+                    After you made changes to the files please click the
+                    evaluation button to check all answers again!
+                  </p>
+                  <p>
+                    <Checkbox onChange={onSureToEditFilesChange}>
+                      I understand this and want to do it anyway
+                    </Checkbox>
+                  </p>
                 </>
               }
               type="warning"
@@ -181,9 +191,20 @@ const TaskDetailsPage: React.FC<{ editable: boolean }> = ({ editable }) => {
                 icon="edit"
                 disabled={assignmentOpen && !sureToEditFiles}
               >
-                Open task files in IDE
+                Edit task files in IDE
               </Button>
-            </Link>
+            </Link>{' '}
+            {task.assignment?.id && (
+              <StartSubmissionEvaluationButton
+                assignmentId={task.assignment.id}
+                invalidateTask={task.id}
+                disabled={assignmentOpen && !sureToEditFiles}
+                type="primary"
+                icon="sync"
+              >
+                Evaluate all answers of this task
+              </StartSubmissionEvaluationButton>
+            )}
           </p>
           <Row gutter={16}>
             <Col span={12}>

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
@@ -19,7 +19,6 @@ import org.codefreak.codefreak.repository.EvaluationStepDefinitionRepository
 import org.codefreak.codefreak.repository.TaskRepository
 import org.codefreak.codefreak.service.AnswerDeadlineReachedEvent
 import org.codefreak.codefreak.service.AnswerService
-import org.codefreak.codefreak.service.AssignmentService
 import org.codefreak.codefreak.service.AssignmentStatusChangedEvent
 import org.codefreak.codefreak.service.BaseService
 import org.codefreak.codefreak.service.ContainerService
@@ -56,9 +55,6 @@ class EvaluationService : BaseService() {
   private lateinit var answerService: AnswerService
 
   @Autowired
-  private lateinit var assignmentService: AssignmentService
-
-  @Autowired
   private lateinit var evaluationQueue: EvaluationQueue
 
   @Autowired
@@ -76,10 +72,7 @@ class EvaluationService : BaseService() {
   }
 
   @Transactional
-  fun startAssignmentEvaluation(assignmentId: UUID, force: Boolean = false): List<Answer> {
-    if (force) {
-      invalidateEvaluations(assignmentService.findAssignment(assignmentId))
-    }
+  fun startAssignmentEvaluation(assignmentId: UUID): List<Answer> {
     val submissions = submissionService.findSubmissionsOfAssignment(assignmentId)
     return submissions.flatMap { it.answers }.mapNotNull {
       try {
@@ -116,6 +109,9 @@ class EvaluationService : BaseService() {
 
   @Transactional
   fun invalidateEvaluations(task: Task) {
+    if (log.isDebugEnabled) {
+      log.debug("Invalidating evaluations of task '${task.title}' (taskId=${task.id})")
+    }
     task.evaluationSettingsChangedAt = Instant.now()
   }
 


### PR DESCRIPTION
* Removed evaluation button above submission table
* Placed evaluation button beside "Edit task files" button
* Save task files from IDE if teacher re-evaluates answers of task