### PR TITLE
Do not persist sessions between restarts

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,9 @@ server:
       # Set server-side timeout of cookies
       # The client session-cookie will expire on browser close by default
       timeout: 24h
+      # Do not persist sessions between server restarts
+      # This will lead to weird issues where Tomcat's and Spring's session storage get out of sync
+      persistent: false
 
 codefreak:
   instanceId: default


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
Tomcat persits sessions between server restarts which leads to weird behaviour.
Spring's SessionRegistry does not get populated on restart but the user is still authenticated on tomcat.

## :link: Related Issues
* Fixes #380