### PR TITLE
Fix multiple uploads of task pool with multiple files

### DIFF
--- a/client/src/components/UploadTasksButton.tsx
+++ b/client/src/components/UploadTasksButton.tsx
@@ -41,8 +41,12 @@ const UploadTasksButton = (props: UploadTasksButtonProps) => {
   )
 
   const beforeUpload = useCallback(
-    (_: RcFile, fileList: RcFile[]) => {
-      onUpload(fileList)
+    (file: RcFile, fileList: RcFile[]) => {
+      // this function is called for every file, but the upload of the whole file list should run only once
+      if (fileList.indexOf(file) === 0) {
+        onUpload(fileList)
+      }
+
       return false
     },
     [onUpload]


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
Fixes a bug where the upload of the task pool is triggered multiple times when the user gives multiple files as input.

## :link: Related Issues
* Fixes # (issue)

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
