### PR TITLE
Fix page reload on evaluation step edit

### DIFF
--- a/client/src/components/JsonSchemaEditButton.less
+++ b/client/src/components/JsonSchemaEditButton.less
@@ -58,4 +58,8 @@
   > .form-group:last-child {
     margin-bottom: 0;
   }
+  // hide submit button
+  .fake-submit {
+    display: none;
+  }
 }

--- a/client/src/components/JsonSchemaEditButton.tsx
+++ b/client/src/components/JsonSchemaEditButton.tsx
@@ -18,12 +18,10 @@ function JsonSchemaEditButton<T>(
   props: React.PropsWithChildren<JsonSchemaEditButtonProps<T>>
 ) {
   const [idPrefix] = useState(Math.random().toString(36).substring(2))
-  const formRef = createRef<Form<any>>()
   const [modalVisible, setModalVisible] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const showModal = () => setModalVisible(true)
   const hideModal = () => setModalVisible(false)
-  const trySubmit = () => formRef.current && formRef.current.submit()
   const onSubmit = ({ formData }: { formData: T }) => {
     setSubmitting(true)
     props
@@ -31,6 +29,17 @@ function JsonSchemaEditButton<T>(
       .then(hideModal)
       .finally(() => setSubmitting(false))
   }
+
+  // react-jsonschema-form does not support programmatic form submission
+  // so we have to add a hidden submit button and trigger a click on it
+  // @see https://github.com/rjsf-team/react-jsonschema-form/issues/500
+  const submitRef = createRef<HTMLButtonElement>()
+  const trySubmit = () => submitRef.current && submitRef.current.click()
+  const fakeSubmit = (
+    <button className="fake-submit" type="submit" ref={submitRef}>
+      Submit
+    </button>
+  )
 
   return (
     <>
@@ -51,12 +60,11 @@ function JsonSchemaEditButton<T>(
         <div className="bootstrap">
           <Form
             showErrorList={false}
-            ref={formRef}
             schema={props.schema}
             formData={props.value}
             idPrefix={idPrefix}
             onSubmit={onSubmit}
-            children={<></>} // hide submit button
+            children={fakeSubmit}
           />
         </div>
       </Modal>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
Somehow the "OK" button in the evaluation step edit modal now causes a page reload (at least in Firefox).
Looks like `react-jsonschema-form` never supported programmatic form submission.
I'm not sure why this worked before and stopped working now.
The workaround I found in rjsf-team/react-jsonschema-form#500 is to create a hidden submit button and trigger `click` on it.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
