### PR TITLE
No Internal Server Error when parsing an invalid codefreak.yml

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -35,9 +35,10 @@ import { HideNavigationProvider } from './hooks/useHideNavigation'
 
 const App: React.FC<{ onUserChanged?: () => void }> = props => {
   const onUserChanged = props.onUserChanged || noop
-  const [authenticatedUser, setAuthenticatedUser] = useState<
-    AuthenticatedUser
-  >()
+  const [
+    authenticatedUser,
+    setAuthenticatedUser
+  ] = useState<AuthenticatedUser>()
   const timeOffset = useCalculatedServerTimeOffset()
 
   const { data: authResult, loading } = useGetAuthenticatedUserQuery({

--- a/client/src/components/InlineError.tsx
+++ b/client/src/components/InlineError.tsx
@@ -1,0 +1,28 @@
+import React, { ReactNode } from 'react'
+import { Alert } from 'antd'
+
+type InineErrorProps = {
+  title: string | ReactNode
+  message: string | ReactNode
+}
+
+const InlineError = (props: InineErrorProps) => {
+  // Wrap error message to retain formatting
+  const formattedErrorMessage = (
+    <code>
+      <pre>{props.message}</pre>
+    </code>
+  )
+
+  return (
+    <Alert
+      message={props.title}
+      description={formattedErrorMessage}
+      type="error"
+      showIcon
+      style={{ marginBottom: 16 }}
+    />
+  )
+}
+
+export default InlineError

--- a/src/main/kotlin/org/codefreak/codefreak/graphql/ErrorHandler.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/graphql/ErrorHandler.kt
@@ -8,6 +8,7 @@ import graphql.language.SourceLocation
 import org.codefreak.codefreak.auth.NotAuthenticatedException
 import org.codefreak.codefreak.service.EntityNotFoundException
 import org.codefreak.codefreak.service.ResourceLimitException
+import org.codefreak.codefreak.util.InvalidCodefreakDefinitionException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.stereotype.Component
@@ -31,7 +32,7 @@ class ErrorHandler : DefaultGraphQLErrorHandler() {
           is AccessDeniedException -> CustomError(it, "Access Denied", "403")
           is BadCredentialsException -> CustomError(it, "Bad Credentials", "422")
           is ResourceLimitException -> CustomError(it, it.message, "503")
-          is IllegalArgumentException, is IllegalStateException -> CustomError(it, it.exception.message ?: it.message, "422")
+          is IllegalArgumentException, is IllegalStateException, is InvalidCodefreakDefinitionException -> CustomError(it, it.exception.message ?: it.message, "422")
           else -> it
         }
       } else it

--- a/src/main/kotlin/org/codefreak/codefreak/util/InvalidCodefreakDefinitionException.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/InvalidCodefreakDefinitionException.kt
@@ -1,0 +1,3 @@
+package org.codefreak.codefreak.util
+
+class InvalidCodefreakDefinitionException(message: String) : RuntimeException("Invalid ${TarUtil.CODEFREAK_DEFINITION_YML}: $message")

--- a/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
@@ -165,26 +165,27 @@ object TarUtil {
   }
 
   inline fun <T> findFile(`in`: InputStream, path: String, consumer: (TarArchiveEntry, TarArchiveInputStream) -> T): T {
+    return findFile(`in`, listOf(path), consumer)
+  }
+
+  inline fun <T> findFile(`in`: InputStream, possiblePaths: List<String>, consumer: (TarArchiveEntry, TarArchiveInputStream) -> T): T {
     TarArchiveInputStream(`in`).let { tar ->
       generateSequence { tar.nextTarEntry }.forEach {
-        if (it.isFile && normalizeEntryName(it.name) == normalizeEntryName(path)) {
-          return consumer(it, tar)
+        possiblePaths.forEach { path ->
+          if (it.isFile && normalizeEntryName(it.name) == normalizeEntryName(path)) {
+            return consumer(it, tar)
+          }
         }
       }
     }
-    throw IllegalArgumentException("$path does not exist")
+
+    throw IllegalArgumentException("None of $possiblePaths does exist")
   }
 
   @Throws(IllegalArgumentException::class)
   inline fun <reified T> ObjectMapper.getCodefreakDefinition(`in`: InputStream): T {
-    try {
-      findFile(`in`, CODEFREAK_DEFINITION_YML) { _, fileStream ->
-        return readValue(fileStream, T::class.java)
-      }
-    } catch (e: IllegalArgumentException) {
-      findFile(`in`, CODEFREAK_DEFINITION_YAML) { _, fileStream ->
-        return readValue(fileStream, T::class.java)
-      }
+    findFile(`in`, listOf(CODEFREAK_DEFINITION_YML, CODEFREAK_DEFINITION_YAML)) { _, fileStream ->
+      return readValue(fileStream, T::class.java)
     }
   }
 

--- a/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
@@ -1,5 +1,6 @@
 package org.codefreak.codefreak.util
 
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.io.BufferedInputStream
 import java.io.ByteArrayInputStream
@@ -182,10 +183,14 @@ object TarUtil {
     throw IllegalArgumentException("None of $possiblePaths does exist")
   }
 
-  @Throws(IllegalArgumentException::class)
+  @Throws(IllegalArgumentException::class, InvalidCodefreakDefinitionException::class)
   inline fun <reified T> ObjectMapper.getCodefreakDefinition(`in`: InputStream): T {
     findFile(`in`, listOf(CODEFREAK_DEFINITION_YML, CODEFREAK_DEFINITION_YAML)) { _, fileStream ->
-      return readValue(fileStream, T::class.java)
+      try {
+        return readValue(fileStream, T::class.java)
+      } catch (e: JsonMappingException) {
+        throw InvalidCodefreakDefinitionException(e.originalMessage)
+      }
     }
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
When the codefreak.yml has an invalid syntax, it cannot be parsed and an exception is thrown. In the frontend this is only shown as an Internal Server Error, which has no value for the user about what went wrong.
The exception is catched and given to the user so he knows what he can do about it.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
