### PR TITLE
Fix incorrect order of evaluation step definitions on export

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/entity/EvaluationStepDefinition.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/entity/EvaluationStepDefinition.kt
@@ -18,7 +18,7 @@ class EvaluationStepDefinition(
   @Column(length = 1024)
   @ColumnDefault("'{}'")
   var options: Map<String, Any> = mapOf()
-) : BaseEntity() {
+) : BaseEntity(), Comparable<EvaluationStepDefinition> {
   var active: Boolean = true
 
   /**
@@ -33,4 +33,6 @@ class EvaluationStepDefinition(
     }
     return super.equals(other)
   }
+
+  override fun compareTo(other: EvaluationStepDefinition) = position - other.position
 }

--- a/src/main/kotlin/org/codefreak/codefreak/entity/Task.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/entity/Task.kt
@@ -6,6 +6,7 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
+import javax.persistence.OrderBy
 import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.Type
@@ -69,7 +70,11 @@ class Task(
   var updatedAt: Instant = Instant.now()
 
   @OneToMany(mappedBy = "task", cascade = [CascadeType.REMOVE])
-  var evaluationStepDefinitions: MutableSet<EvaluationStepDefinition> = mutableSetOf()
+  @OrderBy("position ASC")
+  var evaluationStepDefinitions: MutableSet<EvaluationStepDefinition> = sortedSetOf()
+    set(evaluationStepDefinitions) {
+      field = evaluationStepDefinitions.toSortedSet()
+    }
 
   var evaluationSettingsChangedAt: Instant = Instant.now()
 

--- a/src/main/kotlin/org/codefreak/codefreak/graphql/api/EvaluationApi.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/graphql/api/EvaluationApi.kt
@@ -8,6 +8,7 @@ import com.expediagroup.graphql.spring.operations.Subscription
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.schema.DataFetchingEnvironment
+import java.util.UUID
 import org.codefreak.codefreak.auth.Authority
 import org.codefreak.codefreak.auth.Authorization
 import org.codefreak.codefreak.auth.hasAuthority
@@ -24,12 +25,10 @@ import org.codefreak.codefreak.graphql.SubscriptionEventPublisher
 import org.codefreak.codefreak.service.AnswerService
 import org.codefreak.codefreak.service.AssignmentService
 import org.codefreak.codefreak.service.EvaluationStatusUpdatedEvent
-import org.codefreak.codefreak.service.EvaluationStepStatusUpdatedEvent
 import org.codefreak.codefreak.service.IdeService
 import org.codefreak.codefreak.service.TaskService
 import org.codefreak.codefreak.service.evaluation.EvaluationRunner
 import org.codefreak.codefreak.service.evaluation.EvaluationService
-import org.codefreak.codefreak.service.evaluation.EvaluationStepService
 import org.codefreak.codefreak.service.evaluation.StoppableEvaluationRunner
 import org.codefreak.codefreak.service.evaluation.isBuiltIn
 import org.codefreak.codefreak.util.exhaustive
@@ -39,7 +38,6 @@ import org.springframework.security.access.annotation.Secured
 import org.springframework.stereotype.Component
 import org.springframework.util.Base64Utils
 import reactor.core.publisher.Flux
-import java.util.UUID
 
 @GraphQLName("EvaluationStepDefinition")
 class EvaluationStepDefinitionDto(definition: EvaluationStepDefinition, ctx: ResolverContext) {

--- a/src/main/kotlin/org/codefreak/codefreak/service/TaskTarService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/TaskTarService.kt
@@ -32,19 +32,19 @@ class TaskTarService : BaseService() {
 
   @Autowired
   @Qualifier("yamlObjectMapper")
-  internal lateinit var yamlMapper: ObjectMapper
+  private lateinit var yamlMapper: ObjectMapper
 
   @Autowired
-  internal lateinit var taskService: TaskService
+  private lateinit var taskService: TaskService
 
   @Autowired
-  internal lateinit var evaluationService: EvaluationService
+  private lateinit var evaluationService: EvaluationService
 
   @Autowired
-  internal lateinit var evaluationStepDefinitionRepository: EvaluationStepDefinitionRepository
+  private lateinit var evaluationStepDefinitionRepository: EvaluationStepDefinitionRepository
 
   @Autowired
-  internal lateinit var fileService: FileService
+  private lateinit var fileService: FileService
 
   /**
    * Creates and saves a new task from the given tar.

--- a/src/main/kotlin/org/codefreak/codefreak/service/TaskTarService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/TaskTarService.kt
@@ -110,7 +110,7 @@ class TaskTarService : BaseService() {
         evaluationService.validateRunnerOptions(stepDefinition)
         stepDefinition
       }
-      .toMutableSet()
+      .toSortedSet()
 
   private fun validateEvaluationSteps(task: Task) = task.evaluationStepDefinitions
       .groupBy { it.runnerName }
@@ -227,7 +227,9 @@ class TaskTarService : BaseService() {
       task.body,
       task.hiddenFiles,
       task.protectedFiles,
-      task.evaluationStepDefinitions.map {
+      task.evaluationStepDefinitions
+        .toSortedSet()
+        .map {
         EvaluationDefinition(
             it.runnerName,
             it.options,

--- a/src/main/kotlin/org/codefreak/codefreak/service/TaskTarService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/TaskTarService.kt
@@ -32,19 +32,19 @@ class TaskTarService : BaseService() {
 
   @Autowired
   @Qualifier("yamlObjectMapper")
-  private lateinit var yamlMapper: ObjectMapper
+  internal lateinit var yamlMapper: ObjectMapper
 
   @Autowired
-  private lateinit var taskService: TaskService
+  internal lateinit var taskService: TaskService
 
   @Autowired
-  private lateinit var evaluationService: EvaluationService
+  internal lateinit var evaluationService: EvaluationService
 
   @Autowired
-  private lateinit var evaluationStepDefinitionRepository: EvaluationStepDefinitionRepository
+  internal lateinit var evaluationStepDefinitionRepository: EvaluationStepDefinitionRepository
 
   @Autowired
-  private lateinit var fileService: FileService
+  internal lateinit var fileService: FileService
 
   /**
    * Creates and saves a new task from the given tar.

--- a/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
@@ -70,7 +70,7 @@ class TaskTarServiceTest {
   fun `EvaluationStepDefinitions keep positions on import`() {
     val user = User("Dummy user")
     val task = Task(null, user, 0, "Dummy task")
-    task.evaluationStepDefinitions = createUnorderedEvaluationStepDefinitionSet(task)
+    task.evaluationStepDefinitions = createUnorderedEvaluationStepDefinitionSet(task).toMutableSet()
 
     val exportedTar = taskTarService.getExportTar(task)
     val importedTask = taskTarService.createFromTar(exportedTar, user)
@@ -85,7 +85,7 @@ class TaskTarServiceTest {
     }
   }
 
-  private fun createUnorderedEvaluationStepDefinitionSet(task: Task) = mutableSetOf(
+  private fun createUnorderedEvaluationStepDefinitionSet(task: Task) = setOf(
     EvaluationStepDefinition(task, "comments", 0, "Comments"),
     EvaluationStepDefinition(task, "codeclimate", 1, "Code Quality 1"),
     EvaluationStepDefinition(task, "junit", 5, "Unit tests 1"),

--- a/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
@@ -16,11 +16,14 @@ import org.codefreak.codefreak.service.file.FileService
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.mockito.Spy
 
 class TaskTarServiceTest {
+  @InjectMocks
   private lateinit var taskTarService: TaskTarService
 
   @Mock
@@ -35,19 +38,13 @@ class TaskTarServiceTest {
   @Mock
   private lateinit var mockFileService: FileService
 
+  @Spy
+  internal lateinit var yamlMapper: YAMLMapper
+
   @Before
   fun setUp() {
-    // Note that the use of Mockito here encapsulates the tests of the
-    // implementation details of the dependencies at the cost of performance,
-    // because Mockito seems to trigger the garbage collector
     MockitoAnnotations.openMocks(this)
-
-    taskTarService = TaskTarService()
-
-    taskTarService.yamlMapper = YAMLMapper()
-
     `when`(mockTaskService.saveTask(any())).thenAnswer { it.arguments[0] }
-    taskTarService.taskService = mockTaskService
 
     `when`(mockEvaluationService.getEvaluationRunner(any())).thenAnswer {
       object : EvaluationRunner {
@@ -55,15 +52,12 @@ class TaskTarServiceTest {
         override fun run(answer: Answer, options: Map<String, Any>) = listOf<Feedback>()
       }
     }
-    taskTarService.evaluationService = mockEvaluationService
 
     `when`(mockEvaluationStepDefinitionRepository.save(any())).thenAnswer { it.arguments[0] }
     `when`(mockEvaluationStepDefinitionRepository.saveAll(any())).thenAnswer { it.arguments[0] }
-    taskTarService.evaluationStepDefinitionRepository = mockEvaluationStepDefinitionRepository
 
     `when`(mockFileService.readCollectionTar(any())).thenReturn(ByteArrayInputStream(byteArrayOf()))
     `when`(mockFileService.writeCollectionTar(any())).thenReturn(ByteArrayOutputStream())
-    taskTarService.fileService = mockFileService
   }
 
   @Test

--- a/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
@@ -1,0 +1,112 @@
+package org.codefreak.codefreak.service
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.Optional
+import java.util.UUID
+import org.codefreak.codefreak.entity.Answer
+import org.codefreak.codefreak.entity.EvaluationStepDefinition
+import org.codefreak.codefreak.entity.Feedback
+import org.codefreak.codefreak.entity.Task
+import org.codefreak.codefreak.entity.User
+import org.codefreak.codefreak.repository.EvaluationStepDefinitionRepository
+import org.codefreak.codefreak.service.evaluation.EvaluationRunner
+import org.codefreak.codefreak.service.evaluation.EvaluationService
+import org.codefreak.codefreak.service.file.FileService
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class TaskTarServiceTest {
+  private lateinit var taskTarService: TaskTarService
+
+  @Before
+  fun setUp() {
+    taskTarService = TaskTarService()
+    taskTarService.yamlMapper = YAMLMapper()
+    taskTarService.taskService = createMockTaskService()
+    taskTarService.evaluationService = createMockEvaluationService()
+    taskTarService.evaluationStepDefinitionRepository = createMockEvaluationStepDefinitionRepository()
+    taskTarService.fileService = createMockFileService()
+  }
+
+  // Create own mock object instead of using mockito, because it is quite slow, might be the garbage collector
+  private fun createMockFileService() = object : FileService {
+    override fun readCollectionTar(collectionId: UUID) = ByteArrayInputStream(byteArrayOf())
+    override fun writeCollectionTar(collectionId: UUID) = ByteArrayOutputStream()
+    override fun collectionExists(collectionId: UUID) = true
+    override fun deleteCollection(collectionId: UUID) {}
+    override fun listFiles(collectionId: UUID) = listOf<String>()
+    override fun createFile(collectionId: UUID, path: String) {}
+    override fun createDirectory(collectionId: UUID, path: String) {}
+    override fun containsFile(collectionId: UUID, path: String) = true
+    override fun containsDirectory(collectionId: UUID, path: String) = true
+    override fun deleteFile(collectionId: UUID, path: String) {}
+    override fun filePutContents(collectionId: UUID, path: String) = ByteArrayOutputStream()
+    override fun getFileContents(collectionId: UUID, path: String) = ByteArrayInputStream(byteArrayOf())
+    override fun moveFile(collectionId: UUID, from: String, to: String) {}
+  }
+
+  // Create own mock object instead of using mockito, because it is quite slow, might be the garbage collector
+  private fun createMockTaskService() = object : TaskService() {
+    override fun saveTask(task: Task) = task
+  }
+
+  // Create own mock object instead of using mockito, because it is quite slow, might be the garbage collector
+  private fun createMockEvaluationService() = object : EvaluationService() {
+    override fun getEvaluationRunner(name: String) = object : EvaluationRunner {
+      override fun getName() = name
+      override fun run(answer: Answer, options: Map<String, Any>) = listOf<Feedback>()
+    }
+  }
+
+  // Create own mock object instead of using mockito, because it is quite slow, might be the garbage collector
+  private fun createMockEvaluationStepDefinitionRepository() = object : EvaluationStepDefinitionRepository {
+    override fun <S : EvaluationStepDefinition?> save(entity: S) = entity
+    override fun <S : EvaluationStepDefinition?> saveAll(entities: MutableIterable<S>) = entities
+    override fun findById(id: UUID): Optional<EvaluationStepDefinition> = Optional.empty()
+    override fun existsById(id: UUID) = true
+    override fun findAll() = mutableListOf<EvaluationStepDefinition>()
+    override fun findAllById(ids: MutableIterable<UUID>) = mutableListOf<EvaluationStepDefinition>()
+    override fun count() = 0L
+    override fun deleteById(id: UUID) {}
+    override fun delete(entity: EvaluationStepDefinition) {}
+    override fun deleteAll(entities: MutableIterable<EvaluationStepDefinition>) {}
+    override fun deleteAll() {}
+  }
+
+  @Test
+  fun `EvaluationStepDefinitions keep positions on import`() {
+    val user = User("Dummy user")
+    val task = Task(null, user, 0, "Dummy task")
+    task.evaluationStepDefinitions = createUnorderedEvaluationStepDefinitionSet(task)
+
+    val exportedTar = taskTarService.getExportTar(task)
+    val importedTask = taskTarService.createFromTar(exportedTar, user)
+
+    task.evaluationStepDefinitions.forEach {
+      val importedDefinition = findDefinition(it.title, importedTask.evaluationStepDefinitions)
+      assertEquals(
+        "Step ${it.title} has an incorrect position",
+        it.position,
+        importedDefinition.position
+      )
+    }
+  }
+
+  private fun createUnorderedEvaluationStepDefinitionSet(task: Task) = mutableSetOf(
+    EvaluationStepDefinition(task, "comments", 0, "Comments"),
+    EvaluationStepDefinition(task, "codeclimate", 1, "Code Quality 1"),
+    EvaluationStepDefinition(task, "junit", 5, "Unit tests 1"),
+    EvaluationStepDefinition(task, "codeclimate", 2, "Code Quality 2"),
+    EvaluationStepDefinition(task, "junit", 6, "Unit tests 2"),
+    EvaluationStepDefinition(task, "codeclimate", 3, "Code Quality 3"),
+    EvaluationStepDefinition(task, "junit", 7, "Unit tests 3"),
+    EvaluationStepDefinition(task, "junit", 8, "Unit tests 4"),
+    EvaluationStepDefinition(task, "codeclimate", 4, "Code Quality 4")
+  )
+
+  private fun findDefinition(title: String, definitions: Set<EvaluationStepDefinition>): EvaluationStepDefinition =
+    definitions.find { it.title == title } ?: throw IllegalStateException("Definition $title does not exist")
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
Fixes a bug where the evaluation step definitions of tasks are not exported in the right order, thus are not imported in the right order either.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [x] I have added tests that prove my fix is effective or that my feature works
