### PR TITLE
Export evaluation step default options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Admins can see the author of each assignment (#691)
 * Individual evaluation steps are now run in parallel to make evaluation faster (#710)
 * Make the IDE liveliness check work with URLs from other origin
+* The options of evaluation steps are exported regardless of whether they are the default options or not (#750)
 
 ### Changed
 * Time limit can be specified on assignments and not on individual tasks (#635)

--- a/src/main/kotlin/org/codefreak/codefreak/service/TaskTarService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/TaskTarService.kt
@@ -230,9 +230,15 @@ class TaskTarService : BaseService() {
       task.evaluationStepDefinitions
         .toSortedSet()
         .map {
+          val options =
+            if (it.options.isEmpty())
+              evaluationService.getDefaultOptions(it.runnerName)
+            else
+              it.options
+
         EvaluationDefinition(
             it.runnerName,
-            it.options,
+            options,
             it.title
         )
       }

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationRunner.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationRunner.kt
@@ -18,6 +18,11 @@ interface EvaluationRunner {
   fun getOptionsSchema() = "{}"
 
   /**
+   * Returns the default options for the runner
+   */
+  fun getDefaultOptions() = mapOf<String, Any>()
+
+  /**
    * Default feedback summary is the number of each severities
    */
   fun summarize(feedbackList: List<Feedback>): String {

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
@@ -222,6 +222,11 @@ class EvaluationService : BaseService() {
 
   fun getAllEvaluationRunners() = runners
 
+  /**
+   * Returns the default options for the given evaluation runner
+   */
+  fun getDefaultOptions(runnerName: String) = getEvaluationRunner(runnerName).getDefaultOptions()
+
   fun getEvaluation(evaluationId: UUID): Evaluation {
     return evaluationRepository.findById(evaluationId).orElseThrow { EntityNotFoundException("Evaluation not found") }
   }

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/runner/JUnitRunner.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/runner/JUnitRunner.kt
@@ -28,15 +28,17 @@ class JUnitRunner : CommandLineRunner() {
 
   override fun getOptionsSchema() = ClassPathResource("evaluation/junit.schema.json").inputStream.use { String(it.readBytes()) }
 
+  override fun getDefaultOptions() = mapOf(
+    "image" to "gradle",
+    "project-path" to "/home/gradle/project",
+    "stop-on-fail" to true,
+    "commands" to listOf("gradle testClasses", "gradle test")
+  )
+
   override fun run(answer: Answer, options: Map<String, Any>): List<Feedback> {
     val resultsPath = options.get("results-path", String::class) ?: "build/test-results/test"
     val resultsPattern = TarUtil.normalizeEntryName(resultsPath.withTrailingSlash() + "TEST-.+\\.xml").toRegex()
-    val defaultOptions = mapOf(
-        "image" to "gradle",
-        "project-path" to "/home/gradle/project",
-        "stop-on-fail" to true,
-        "commands" to listOf("gradle testClasses", "gradle test")
-    )
+    val defaultOptions = getDefaultOptions()
     val feedback = mutableListOf<Feedback>()
     super.executeCommands(answer, defaultOptions + options) { files ->
       val tar = TarArchiveInputStream(files)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
If an evaluation step has no options stored and thus uses the default options for its runner, these default options were not exported.
Now those default options are exported if a step has no explicit options.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
