### PR TITLE
Allow to release from v* branches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,12 @@ repositories {
   maven { url 'https://jitpack.io' }
 }
 
+release {
+  git {
+    requireBranch = 'master|v\\d+'
+  }
+}
+
 dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-aop'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
release-plugins currently only allows releases from `master`.

## :link: Related Issues
* Fixes # (issue)

## :ballot_box_with_check: Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
