### PR TITLE
Fetch all tags in GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          # Ensures all refs and tags are fetched so "git describe --always" is working as expected
+          fetch-depth: 0
 
       - name: Cache gradle dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
`actions/checkout@v2` only fetches with a depth of `1` leaving out all other commits and tags.  
We need everything so our version display is working as expected.