### PR TITLE
Fix wrong tag when using actions/checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,11 @@ jobs:
           # Ensures all refs and tags are fetched so "git describe --always" is working as expected
           fetch-depth: 0
 
+      # A workaround for annotated tags with actions/checkout@v2
+      # see https://github.com/actions/checkout/issues/290
+      - name: Fetch Tags correctly
+        run: git fetch --force --tags
+
       - name: Cache gradle dependencies
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
`actions/checkout@v2` has an issue where annotated tags are not checked out correctly.  
This causes `git describe --always` to refer to an older tag.

