### PR TITLE
Remove manifest classpath plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ plugins {
   id 'com.diffplug.spotless' version '5.9.0'
   id 'com.bertramlabs.asset-pipeline' version '3.0.10'
   id 'jacoco'
-  id 'ua.eshepelyuk.ManifestClasspath' version '1.0.0'
   id "com.gorylenko.gradle-git-properties" version "2.2.4"
   id 'net.researchgate.release' version '2.8.1'
   id 'org.liquibase.gradle' version '2.0.4'


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
Since Gradle 6 this is an integrated feature: [What's new in Gradle 6.0 | Executing Java applications with long classpaths](https://gradle.org/whats-new/gradle-6/#executing-java-applications-with-long-classpaths)
Is there a Gradle option where we can require Gradle 6 or later?