### PR TITLE
Allow to mount docker daemon to IDE by a whitelist

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/config/AppConfiguration.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/config/AppConfiguration.kt
@@ -87,7 +87,7 @@ class AppConfiguration {
      * List of IDE image names that will receive the docker daemon as mount
      * This should only be used for Breeze
      */
-    var dockerDaemonWhitelist = arrayListOf(
+    var dockerDaemonAllowlist = arrayListOf(
         "cfreak/breeze"
     )
   }

--- a/src/main/kotlin/org/codefreak/codefreak/config/AppConfiguration.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/config/AppConfiguration.kt
@@ -82,6 +82,14 @@ class AppConfiguration {
      * Default is the "bridge" network (Docker default)
      */
     lateinit var network: String
+
+    /**
+     * List of IDE image names that will receive the docker daemon as mount
+     * This should only be used for Breeze
+     */
+    var dockerDaemonWhitelist = arrayListOf(
+        "cfreak/breeze"
+    )
   }
 
   class Docker {

--- a/src/main/kotlin/org/codefreak/codefreak/service/IdeService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/IdeService.kt
@@ -98,7 +98,7 @@ class IdeService : BaseService() {
 
   private fun shouldMountDockerDaemon(customImage: String?): Boolean {
     val image = customImage ?: config.ide.image
-    return config.ide.dockerDaemonWhitelist.contains(
+    return config.ide.dockerDaemonAllowlist.contains(
         DockerUtil.getImageNameWithoutTag(image)
     )
   }

--- a/src/main/kotlin/org/codefreak/codefreak/util/DockerUtil.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/DockerUtil.kt
@@ -30,4 +30,14 @@ object DockerUtil {
       } else {
         "$imageName:latest"
       }
+
+  /**
+   * Get the image name without tag
+   */
+  fun getImageNameWithoutTag(imageName: String) =
+    if (imageName.contains(':')) {
+      imageName.substringBefore(':')
+    } else {
+      imageName
+    }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
Another tweak required for Breeze. This will mount the Docker daemon into the IDE container if the image name is contained in an admin-defined whitelist. We will only need this for `cfreak/breeze`
