### PR TITLE
Do not upgrade webpack with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,11 +12,18 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "paths": ["+(/client/**)"],
+      "paths": ["+(client/package.json)"],
+      "packageNames": [
+        "webpack"
+      ],
+      "enabled": false
+    },
+    {
+      "paths": ["+(client/package.json)"],
       "addLabels": ["client"]
     },
     {
-      "paths": ["+(**/*.gradle)"],
+      "paths": ["+(build.gradle)"],
       "addLabels": ["backend"]
     },
     {


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
Webpack upgrades will always fail as a react-scripts expects a specific version. We do not need a specific webpack version so lets stick with the version react needs.
