### PR TITLE
Add traefik config to vagrant setup docs

### DIFF
--- a/docs/modules/for-developers/pages/development.adoc
+++ b/docs/modules/for-developers/pages/development.adoc
@@ -94,6 +94,9 @@ When the machine is running (can be confirmed by running `vagrant status`) you c
 codefreak:
   docker:
     host: "http://127.0.0.1:2375"
+  reverse-proxy:
+    type: traefik
+    url: "http://localhost:8081"
 -----
 
 The Code FREAK backend and frontend can still be run locally from your Windows or MacOS machine!


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
If someone uses the Vagrant Docker daemon they will also need to configure Traefik as reverse proxy.