### PR TITLE
Fix blank submission table fields

### DIFF
--- a/client/src/components/SubmissionsTable.test.tsx
+++ b/client/src/components/SubmissionsTable.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { render, unmountComponentAtNode } from 'react-dom'
+import { act } from 'react-dom/test-utils'
+import { GetAssignmentWithSubmissionsQueryResult } from '../services/codefreak-api'
+
+import SubmissionsTable from './SubmissionsTable'
+
+type Assignment = NonNullable<
+  GetAssignmentWithSubmissionsQueryResult['data']
+>['assignment']
+type Submission = Assignment['submissions'][number]
+type User = Submission['user']
+
+let container: Element
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // deprecated, but antd uses it
+      removeListener: jest.fn(), // deprecated, but antd uses it
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn()
+    }))
+  })
+})
+
+afterEach(() => {
+  unmountComponentAtNode(container)
+  container?.remove()
+})
+
+it('renders user data', () => {
+  const dummyUser: User = {
+    id: '',
+    username: 'john-doe',
+    firstName: 'John',
+    lastName: 'Doe'
+  }
+  const dummySubmission: Submission = {
+    id: 'id',
+    user: dummyUser,
+    answers: []
+  }
+  const dummyAssignment: Assignment = {
+    title: 'Dummy assignment',
+    id: 'dummy',
+    submissionsDownloadUrl: '',
+    submissions: [dummySubmission],
+    tasks: []
+  }
+
+  act(() => {
+    render(<SubmissionsTable assignment={dummyAssignment} />, container)
+  })
+
+  expect(container.textContent).toContain(dummyUser.firstName)
+  expect(container.textContent).toContain(dummyUser.lastName)
+  expect(container.textContent).toContain(dummyUser.username)
+})

--- a/client/src/components/SubmissionsTable.tsx
+++ b/client/src/components/SubmissionsTable.tsx
@@ -152,7 +152,7 @@ const SubmissionsTable: React.FC<{ assignment: Assignment }> = ({
     >
       <Column
         title="Last Name"
-        dataIndex="user.lastName"
+        dataIndex={['user', 'lastName']}
         width={200}
         fixed="left"
         defaultSortOrder="ascend"
@@ -160,14 +160,14 @@ const SubmissionsTable: React.FC<{ assignment: Assignment }> = ({
       />
       <Column
         title="First Name"
-        dataIndex="user.firstName"
+        dataIndex={["user", "firstName"]}
         width={200}
         fixed="left"
         sorter={alphabeticSorter(submission => submission.user.firstName)}
       />
       <Column
         title="Username"
-        dataIndex="user.username"
+        dataIndex={["user", "username"]}
         width={300}
         sorter={alphabeticSorter(submission => submission.user.username)}
       />

--- a/client/src/components/SubmissionsTable.tsx
+++ b/client/src/components/SubmissionsTable.tsx
@@ -160,14 +160,14 @@ const SubmissionsTable: React.FC<{ assignment: Assignment }> = ({
       />
       <Column
         title="First Name"
-        dataIndex={["user", "firstName"]}
+        dataIndex={['user', 'firstName']}
         width={200}
         fixed="left"
         sorter={alphabeticSorter(submission => submission.user.firstName)}
       />
       <Column
         title="Username"
-        dataIndex={["user", "username"]}
+        dataIndex={['user', 'username']}
         width={300}
         sorter={alphabeticSorter(submission => submission.user.username)}
       />


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
After the update to antd 4 the cells with user data in the submissions table were blank, because the format for the `dataIndex` property of table columns changed.
This fix changes those inputs to the new format.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [x] I have added tests that prove my fix is effective or that my feature works
