### PR TITLE
Show whether the task pool is empty when the user wants to add tasks to an assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Evaluation step status is shown in real time (#714)
 * If an evaluation step is marked inactive, export this too (#748)
 * The options of evaluation steps are exported regardless of whether they are the default options or not (#750)
+* When adding tasks to an assignment show whether the task pool is empty (#779)
 
 ### Changed
 * Time limit can be specified on assignments and not on individual tasks (#635)

--- a/client/src/pages/assignment/AssignmentPage.tsx
+++ b/client/src/pages/assignment/AssignmentPage.tsx
@@ -12,6 +12,7 @@ import {
   DatePicker,
   Descriptions,
   Dropdown,
+  Empty,
   Form,
   Menu,
   Modal,
@@ -74,6 +75,7 @@ import {
 import { useCreateRoutes } from '../../hooks/useCreateRoutes'
 import { ShareAssignmentButton } from '../../components/ShareAssignmentButton'
 import TimeLimitTag from '../../components/time-limit/TimeLimitTag'
+import { Link } from 'react-router-dom'
 
 const { Step } = Steps
 
@@ -421,6 +423,28 @@ const AddTasksButton: React.FC<{
     />
   )
 
+  const taskSelection = (
+    <>
+      <Row gutter={16}>
+        <Col>{searchBar}</Col>
+        <Col>{sorter}</Col>
+      </Row>
+      <Alert
+        message={
+          'When a task from the pool is added to an assignment, an independent copy is created. ' +
+          'Editing the task in the pool will have no effect on the assignment and vice versa.'
+        }
+        style={{ marginBottom: 16, marginTop: 16 }}
+      />
+      <TaskSelection
+        value={taskIds}
+        setValue={setTaskIds}
+        sortMethod={sortMethod}
+        filterCriteria={filterCriteria}
+      />
+    </>
+  )
+
   return (
     <>
       <Button type="primary" icon={<PlusOutlined />} onClick={showModal}>
@@ -437,23 +461,7 @@ const AddTasksButton: React.FC<{
         }}
         onOk={submit}
       >
-        <Row gutter={16}>
-          <Col>{searchBar}</Col>
-          <Col>{sorter}</Col>
-        </Row>
-        <Alert
-          message={
-            'When a task from the pool is added to an assignment, an independent copy is created. ' +
-            'Editing the task in the pool will have no effect on the assignment and vice versa.'
-          }
-          style={{ marginBottom: 16, marginTop: 16 }}
-        />
-        <TaskSelection
-          value={taskIds}
-          setValue={setTaskIds}
-          sortMethod={sortMethod}
-          filterCriteria={filterCriteria}
-        />
+        {taskSelection}
       </Modal>
     </>
   )
@@ -472,6 +480,15 @@ const TaskSelection: React.FC<{
   }
 
   let taskPool = result.data.taskPool.slice()
+
+  if (taskPool.length === 0) {
+    return (
+      <Empty description={<span>Your task pool is empty.</span>}>
+        <Link to="/tasks/pool">Go to the task pool</Link> and create or import
+        your first task!
+      </Empty>
+    )
+  }
 
   if (props.filterCriteria) {
     taskPool = filterTasks(taskPool, props.filterCriteria)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
When the user wants to add task to the assignment but the task pool is empty, show this and give a call to action.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
