### PR TITLE
Tell the user what went wrong when uploading/importing an invalid archive format

### DIFF
--- a/client/src/components/UploadTasksButton.tsx
+++ b/client/src/components/UploadTasksButton.tsx
@@ -54,7 +54,7 @@ const UploadTasksButton = (props: UploadTasksButtonProps) => {
   const inlineError =
     inlineErrorMessage.length > 0 ? (
       <InlineError
-        title="Error while importing assignment"
+        title="Error while importing task(s)"
         message={inlineErrorMessage}
       />
     ) : null

--- a/src/main/kotlin/org/codefreak/codefreak/graphql/ErrorHandler.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/graphql/ErrorHandler.kt
@@ -8,6 +8,7 @@ import graphql.language.SourceLocation
 import org.codefreak.codefreak.auth.NotAuthenticatedException
 import org.codefreak.codefreak.service.EntityNotFoundException
 import org.codefreak.codefreak.service.ResourceLimitException
+import org.codefreak.codefreak.util.InvalidArchiveFormatException
 import org.codefreak.codefreak.util.InvalidCodefreakDefinitionException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.BadCredentialsException
@@ -32,7 +33,7 @@ class ErrorHandler : DefaultGraphQLErrorHandler() {
           is AccessDeniedException -> CustomError(it, "Access Denied", "403")
           is BadCredentialsException -> CustomError(it, "Bad Credentials", "422")
           is ResourceLimitException -> CustomError(it, it.message, "503")
-          is IllegalArgumentException, is IllegalStateException, is InvalidCodefreakDefinitionException -> CustomError(it, it.exception.message ?: it.message, "422")
+          is IllegalArgumentException, is IllegalStateException, is InvalidCodefreakDefinitionException, is InvalidArchiveFormatException -> CustomError(it, it.exception.message ?: it.message, "422")
           else -> it
         }
       } else it

--- a/src/main/kotlin/org/codefreak/codefreak/util/InvalidArchiveFormatException.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/InvalidArchiveFormatException.kt
@@ -1,0 +1,3 @@
+package org.codefreak.codefreak.util
+
+class InvalidArchiveFormatException : RuntimeException("The format of the archive is not supported (or it is not even an archive at all!)")

--- a/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
@@ -226,7 +226,7 @@ object TarUtil {
       try {
         // try to read upload as archive
         return files[0].inputStream.use { archiveToTar(it, out) }
-      } catch (e: ArchiveException) {
+      } catch (e: InvalidArchiveFormatException) {
         // unknown archive type or no archive at all
         // create a new tar archive that contains only the uploaded file
       }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
When uploading/importing an archive with a format that is not supported by the backend, the frontend shows a generic `InternalServerError`.
This fix tells the user that the archive is not supported.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
