### PR TITLE
Custom Spring error pages rendered by React

### DIFF
--- a/client/src/StandaloneErrorPage.less
+++ b/client/src/StandaloneErrorPage.less
@@ -1,0 +1,19 @@
+.error-root {
+  text-align: center;
+  max-width: 500px;
+}
+
+.codefreak-logo {
+  transition: filter 250ms;
+  filter: grayscale(100%);
+
+  a:hover &,
+  a:focus & {
+    filter: grayscale(0);
+  }
+}
+
+.error-details {
+  font-size: 120%;
+  color: gray;
+}

--- a/client/src/StandaloneErrorPage.tsx
+++ b/client/src/StandaloneErrorPage.tsx
@@ -1,0 +1,33 @@
+import Centered from './components/Centered'
+import Logo from './components/Logo'
+import { Button } from 'antd'
+import { HomeFilled } from '@ant-design/icons'
+
+import './StandaloneErrorPage.less'
+
+interface StandaloneErrorPageProps {
+  error: CodefreakError
+}
+
+const StandaloneErrorPage: React.FC<StandaloneErrorPageProps> = ({ error }) => {
+  return (
+    <Centered>
+      <div className="error-root">
+        <div>
+          <a href="/">
+            <Logo className="codefreak-logo" width={200} />
+          </a>
+        </div>
+        <h1>
+          Error {error.status} – {error.error}
+        </h1>
+        <p className="error-details">{error.message}</p>
+        <Button href="/" type="primary" icon={<HomeFilled />} size="large">
+          Return to Home
+        </Button>
+      </div>
+    </Centered>
+  )
+}
+
+export default StandaloneErrorPage

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -1,0 +1,20 @@
+declare global {
+  /**
+   * Object that is exposed by the Spring backend via window.__CODEFREAK_ERROR
+   * for server-side errors
+   */
+  interface CodefreakError {
+    timestamp: string
+    status: number
+    message: string
+    error: string
+    trace?: string
+    path: string
+  }
+
+  interface Window {
+    __CODEFREAK_ERROR: CodefreakError
+  }
+}
+
+export {}

--- a/client/src/services/codefreak-api.ts
+++ b/client/src/services/codefreak-api.ts
@@ -1,4 +1,10 @@
 import { GraphQLError } from 'graphql'
+import { ApolloClient, ApolloLink, InMemoryCache, split } from '@apollo/client'
+import { onError } from '@apollo/client/link/error'
+import { messageService } from './message'
+import { getMainDefinition } from '@apollo/client/utilities'
+import { createUploadLink } from 'apollo-upload-client'
+import { WebSocketLink } from '@apollo/client/link/ws'
 
 export * from '../generated/graphql'
 
@@ -6,4 +12,53 @@ export const extractErrorMessage = (error: {
   graphQLErrors?: ReadonlyArray<GraphQLError>
 }) => {
   return (error.graphQLErrors || []).map(e => e.message).join('\n')
+}
+
+export const createHttpLink = () =>
+  createUploadLink({ uri: '/graphql', credentials: 'include' })
+
+export const createApolloWsLink = () => {
+  const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return new WebSocketLink({
+    uri: `${wsProtocol}//${window.location.host}/subscriptions`,
+    options: {
+      reconnect: true,
+      connectionParams: {
+        credentials: 'include'
+      }
+    }
+  })
+}
+
+export const createApolloClient = (wsLink: WebSocketLink) => {
+  return new ApolloClient({
+    link: ApolloLink.from([
+      onError(error => {
+        if (!error.operation.getContext().disableGlobalErrorHandling) {
+          // If not authenticated or session expired, reload page to show login dialog
+          if ((error as any).networkError?.extensions?.errorCode === '401') {
+            window.location.reload()
+          }
+          messageService.error(extractErrorMessage(error))
+        }
+      }),
+      split(
+        ({ query }) => {
+          const definition = getMainDefinition(query)
+          return (
+            definition.kind === 'OperationDefinition' &&
+            definition.operation === 'subscription'
+          )
+        },
+        wsLink,
+        createHttpLink()
+      )
+    ]),
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        fetchPolicy: 'cache-and-network'
+      }
+    }
+  })
 }

--- a/src/main/kotlin/org/codefreak/codefreak/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/config/SecurityConfiguration.kt
@@ -1,5 +1,6 @@
 package org.codefreak.codefreak.config
 
+import javax.servlet.http.HttpServletResponse
 import org.codefreak.codefreak.auth.AuthenticationMethod
 import org.codefreak.codefreak.auth.LdapUserDetailsContextMapper
 import org.codefreak.codefreak.auth.SimpleUserDetailsService
@@ -22,7 +23,6 @@ import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider
 import org.springframework.security.web.firewall.RequestRejectedHandler
 import org.springframework.security.web.session.HttpSessionEventPublisher
-import javax.servlet.http.HttpServletResponse
 
 @Configuration
 class SecurityConfiguration : WebSecurityConfigurerAdapter() {

--- a/src/main/kotlin/org/codefreak/codefreak/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/config/SecurityConfiguration.kt
@@ -20,7 +20,9 @@ import org.springframework.security.core.session.SessionRegistry
 import org.springframework.security.core.session.SessionRegistryImpl
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider
+import org.springframework.security.web.firewall.RequestRejectedHandler
 import org.springframework.security.web.session.HttpSessionEventPublisher
+import javax.servlet.http.HttpServletResponse
 
 @Configuration
 class SecurityConfiguration : WebSecurityConfigurerAdapter() {
@@ -106,5 +108,13 @@ class SecurityConfiguration : WebSecurityConfigurerAdapter() {
         ?.groupSearchFilter(config.ldap.groupSearchFilter)
         ?.contextSource()
             ?.url(url.withTrailingSlash() + config.ldap.rootDn)
+  }
+
+  @Bean
+  fun requestRejectedHandler(): RequestRejectedHandler {
+    // return 400 instead of 500 for firewalled requests
+    return RequestRejectedHandler { _, response, requestRejectedException ->
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, requestRejectedException.message)
+    }
   }
 }

--- a/src/main/kotlin/org/codefreak/codefreak/frontend/DevErrorController.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/frontend/DevErrorController.kt
@@ -1,0 +1,31 @@
+package org.codefreak.codefreak.frontend
+
+import javax.servlet.http.HttpServletRequest
+import org.codefreak.codefreak.Env
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.web.ServerProperties
+import org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorViewResolver
+import org.springframework.boot.web.error.ErrorAttributeOptions
+import org.springframework.boot.web.servlet.error.ErrorAttributes
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+
+/**
+ * Custom ErrorController that includes the stacktrace if we are in a development environment
+ * By default the stacktrace is disabled via the application.yml
+ */
+@Component
+@Profile(Env.DEV)
+class DevErrorController(
+  @Autowired errorAttributes: ErrorAttributes,
+  @Autowired serverProperties: ServerProperties,
+  @Autowired errorViewResolvers: ObjectProvider<ErrorViewResolver>
+) : BasicErrorController(errorAttributes, serverProperties.error, errorViewResolvers.toList()) {
+
+  override fun getErrorAttributeOptions(request: HttpServletRequest?, mediaType: MediaType?): ErrorAttributeOptions {
+    return super.getErrorAttributeOptions(request, mediaType).including(ErrorAttributeOptions.Include.STACK_TRACE)
+  }
+}

--- a/src/main/kotlin/org/codefreak/codefreak/frontend/InjectedScriptErrorView.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/frontend/InjectedScriptErrorView.kt
@@ -1,0 +1,40 @@
+package org.codefreak.codefreak.frontend
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.charset.Charset
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import org.apache.commons.io.IOUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.View
+
+/**
+ * Error view that injects a script into a HTML template before the first <script tag.
+ * It exposes a global JS variable named "__CODEFREAK_ERROR" that includes all error attributes
+ */
+@Component("error")
+class InjectedScriptErrorView : View {
+  @Autowired
+  private lateinit var applicationContext: ApplicationContext
+
+  @Autowired
+  private lateinit var objectMapper: ObjectMapper
+
+  private fun buildErrorJsonScriptTag(data: Map<String, *>?): String {
+    val json = objectMapper.writeValueAsString(data)
+    return "<script>const __CODEFREAK_ERROR = $json;</script>"
+  }
+
+  override fun render(model: MutableMap<String, *>?, request: HttpServletRequest, response: HttpServletResponse) {
+    val error = applicationContext.getResource("classpath:static/index.html")
+    val content = IOUtils.toString(error.inputStream, Charset.defaultCharset())
+    var errorScriptTag = buildErrorJsonScriptTag(model)
+    if (content.contains("\n")) {
+      errorScriptTag += "\n"
+    }
+    val body = content.replaceFirst("<script", "$errorScriptTag<script")
+    response.writer.append(body)
+  }
+}

--- a/src/main/kotlin/org/codefreak/codefreak/frontend/InjectedScriptErrorView.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/frontend/InjectedScriptErrorView.kt
@@ -24,7 +24,7 @@ class InjectedScriptErrorView : View {
 
   private fun buildErrorJsonScriptTag(data: Map<String, *>?): String {
     val json = objectMapper.writeValueAsString(data)
-    return "<script>const __CODEFREAK_ERROR = $json;</script>"
+    return "<script>window.__CODEFREAK_ERROR = $json;</script>"
   }
 
   override fun render(model: MutableMap<String, *>?, request: HttpServletRequest, response: HttpServletResponse) {

--- a/src/main/kotlin/org/codefreak/codefreak/frontend/ReactErrorViewResolver.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/frontend/ReactErrorViewResolver.kt
@@ -1,0 +1,24 @@
+package org.codefreak.codefreak.frontend
+
+import javax.servlet.http.HttpServletRequest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorViewResolver
+import org.springframework.core.Ordered
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.ModelAndView
+import org.springframework.web.servlet.View
+
+@Component
+class ReactErrorViewResolver : ErrorViewResolver, Ordered {
+  @Autowired
+  @Qualifier("error")
+  private lateinit var errorView: View
+
+  override fun resolveErrorView(request: HttpServletRequest?, status: HttpStatus?, model: MutableMap<String, Any>?): ModelAndView {
+    return ModelAndView(errorView, model)
+  }
+
+  override fun getOrder() = Ordered.HIGHEST_PRECEDENCE
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,9 @@ graphql:
     - "org.codefreak.codefreak.graphql.api"
 
 server:
+  error:
+    # there is a custom ErrorController that will include the stacktrace in dev environment
+    include-stacktrace: never
   servlet:
     session:
       # Set server-side timeout of cookies

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,104 @@
+<html lang="en">
+<!--
+  This file will serve as a placeholder during development when the React frontend is not served via Spring.
+  When building the application the gradle task "deployFrontend" will replace this file with client/build/index.html.
+-->
+<head>
+  <title>Code FREAK</title>
+  <style>
+    html {
+      box-sizing: border-box;
+      font-size: 16px;
+      font-family: sans-serif;
+    }
+
+    body, h1, h2, h3, h4, h5, h6, ol, ul {
+      margin: 0;
+      padding: 0;
+      font-weight: normal;
+    }
+
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+
+    pre {
+      overflow-x: auto;
+    }
+
+    code, pre {
+      font-family: monospace;
+      font-size: 90%;
+    }
+
+    code {
+      background-color: lightgray;
+      padding: 1px 4px;
+      border-radius: 2px;
+    }
+
+    h1, h2 {
+      margin-bottom: 1em;
+    }
+
+    .wrapper {
+      max-width: 1200px;
+      margin: auto;
+      padding-top: 50px;
+    }
+
+    .info {
+      margin: 2em 0;
+      padding: 10px;
+      border: 2px solid lightgray;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+<div class="wrapper">
+  <h1 style="text-align: center">
+    <img alt="Code FREAK" src="https://raw.githubusercontent.com/codefreak/codefreak/master/client/public/logo192.png"
+         width="192"/>
+  </h1>
+  <div id="root"></div>
+  <div class="info">
+    <p>You should only ever see this as a developer if you are running the Code FREAK backend and frontend
+      separately!</p>
+    <p>If you are looking for the frontend it should be available at <a href="http://localhost:3000">http://localhost:3000</a>
+      after running <code>npm start</code> in <code>/client</code>.
+    </p>
+    <p>On a production system this site is replaced by the React frontend. You can try this during development by
+      running
+      the
+      <code>gradle deployFrontend</code> task and restarting the Spring application.</p>
+  </div>
+  <script>
+    // small helper to create elements with content
+    const element = (tag, content) => {
+      const element = document.createElement(tag);
+      if (typeof content === "string") {
+        element.innerText = content;
+      } else if (content instanceof HTMLElement) {
+        element.appendChild(content);
+      }
+      return element;
+    };
+    /** @var {Object} __CODEFREAK_ERROR **/
+    const root = document.getElementById("root");
+    if (typeof __CODEFREAK_ERROR !== "undefined") {
+      // the following lines render the key-value-pairs of __CODEFREAK_ERROR in a <dl/>
+      const statusCode = __CODEFREAK_ERROR["status"];
+      document.getElementsByTagName("title")[0].innerText = `Error ${statusCode} | Code FREAK`;
+      root.innerHTML = `<h2>The following error occurred (<code>__CODEFREAK_ERROR</code>)</h2>`;
+      const dl = root.appendChild(element("dl", ""));
+      for (let key of Object.keys(__CODEFREAK_ERROR)) {
+        dl.appendChild(element("dt", element("code", key)));
+        dl.appendChild(element("dd", element("pre", __CODEFREAK_ERROR[key])));
+      }
+    }
+  </script>
+</div>
+</body>
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,104 +1,127 @@
 <html lang="en">
 <!--
-  This file will serve as a placeholder during development when the React frontend is not served via Spring.
-  When building the application the gradle task "deployFrontend" will replace this file with client/build/index.html.
+This file will serve as a placeholder during development when the React frontend is not served by Spring.
+When building the application the gradle task "deployFrontend" will replace this file with client/build/index.html.
 -->
-<head>
-  <title>Code FREAK</title>
-  <style>
-    html {
-      box-sizing: border-box;
-      font-size: 16px;
-      font-family: sans-serif;
-    }
-
-    body, h1, h2, h3, h4, h5, h6, ol, ul {
-      margin: 0;
-      padding: 0;
-      font-weight: normal;
-    }
-
-    img {
-      max-width: 100%;
-      height: auto;
-    }
-
-    pre {
-      overflow-x: auto;
-    }
-
-    code, pre {
-      font-family: monospace;
-      font-size: 90%;
-    }
-
-    code {
-      background-color: lightgray;
-      padding: 1px 4px;
-      border-radius: 2px;
-    }
-
-    h1, h2 {
-      margin-bottom: 1em;
-    }
-
-    .wrapper {
-      max-width: 1200px;
-      margin: auto;
-      padding-top: 50px;
-    }
-
-    .info {
-      margin: 2em 0;
-      padding: 10px;
-      border: 2px solid lightgray;
-      border-radius: 4px;
-    }
-  </style>
-</head>
-<body>
-<div class="wrapper">
-  <h1 style="text-align: center">
-    <img alt="Code FREAK" src="https://raw.githubusercontent.com/codefreak/codefreak/master/client/public/logo192.png"
-         width="192"/>
-  </h1>
-  <div id="root"></div>
-  <div class="info">
-    <p>You should only ever see this as a developer if you are running the Code FREAK backend and frontend
-      separately!</p>
-    <p>If you are looking for the frontend it should be available at <a href="http://localhost:3000">http://localhost:3000</a>
-      after running <code>npm start</code> in <code>/client</code>.
-    </p>
-    <p>On a production system this site is replaced by the React frontend. You can try this during development by
-      running
-      the
-      <code>gradle deployFrontend</code> task and restarting the Spring application.</p>
-  </div>
-  <script>
-    // small helper to create elements with content
-    const element = (tag, content) => {
-      const element = document.createElement(tag);
-      if (typeof content === "string") {
-        element.innerText = content;
-      } else if (content instanceof HTMLElement) {
-        element.appendChild(content);
+  <head>
+    <title>Code FREAK</title>
+    <style>
+      html {
+        box-sizing: border-box;
+        font-size: 16px;
+        font-family: sans-serif;
       }
-      return element;
-    };
-    /** @var {Object} __CODEFREAK_ERROR **/
-    const root = document.getElementById("root");
-    if (typeof __CODEFREAK_ERROR !== "undefined") {
-      // the following lines render the key-value-pairs of __CODEFREAK_ERROR in a <dl/>
-      const statusCode = __CODEFREAK_ERROR["status"];
-      document.getElementsByTagName("title")[0].innerText = `Error ${statusCode} | Code FREAK`;
-      root.innerHTML = `<h2>The following error occurred (<code>__CODEFREAK_ERROR</code>)</h2>`;
-      const dl = root.appendChild(element("dl", ""));
-      for (let key of Object.keys(__CODEFREAK_ERROR)) {
-        dl.appendChild(element("dt", element("code", key)));
-        dl.appendChild(element("dd", element("pre", __CODEFREAK_ERROR[key])));
+
+      body,
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      ol,
+      ul {
+        margin: 0;
+        padding: 0;
+        font-weight: normal;
       }
-    }
-  </script>
-</div>
-</body>
+
+      img {
+        max-width: 100%;
+        height: auto;
+      }
+
+      pre {
+        overflow-x: auto;
+      }
+
+      code,
+      pre {
+        font-family: monospace;
+        font-size: 90%;
+      }
+
+      code {
+        background-color: lightgray;
+        padding: 1px 4px;
+        border-radius: 2px;
+      }
+
+      h1,
+      h2 {
+        margin-bottom: 1em;
+      }
+
+      .wrapper {
+        max-width: 1200px;
+        margin: auto;
+        padding: 50px 20px;
+      }
+
+      .info {
+        margin: 2em 0;
+        padding: 10px;
+        border: 2px solid lightgray;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <h1 style="text-align: center">
+        <img
+          alt="Code FREAK"
+          src="https://raw.githubusercontent.com/codefreak/codefreak/master/client/public/logo192.png"
+          width="192"
+        />
+      </h1>
+      <div id="root"></div>
+      <div class="info">
+        <p>
+          You should only ever see this as a developer if you are running the
+          Code FREAK backend and frontend separately!
+        </p>
+        <p>
+          If you are looking for the frontend it should be available at
+          <a href="http://localhost:3000">http://localhost:3000</a> after
+          running <code>npm start</code> in <code>/client</code>.
+        </p>
+        <p>
+          On a production system this site is replaced by the React frontend.
+          You can try this during development by running the
+          <code>gradle deployFrontend</code> task while the backend ist running.
+        </p>
+      </div>
+      <script>
+        /** @var {Object} __CODEFREAK_ERROR **/
+        const root = document.getElementById("root");
+        if (typeof __CODEFREAK_ERROR !== "undefined") {
+          // small helper to create elements with content
+          const element = (tag, content) => {
+            const element = document.createElement(tag);
+            if (typeof content === "string") {
+              element.innerText = content;
+            } else if (content instanceof HTMLElement) {
+              element.appendChild(content);
+            }
+            return element;
+          };
+
+          // the following lines render the key-value-pairs of __CODEFREAK_ERROR in a <dl/>
+          const statusCode = __CODEFREAK_ERROR["status"];
+          document.getElementsByTagName(
+            "title"
+          )[0].innerText = `Error ${statusCode} | Code FREAK`;
+          root.innerHTML = `<h2>The following error occurred (<code>__CODEFREAK_ERROR</code>)</h2>`;
+          const dl = root.appendChild(element("dl", ""));
+          for (let key of Object.keys(__CODEFREAK_ERROR)) {
+            dl.appendChild(element("dt", element("code", key)));
+            dl.appendChild(
+              element("dd", element("pre", __CODEFREAK_ERROR[key] + ""))
+            );
+          }
+        }
+      </script>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
This PR replaces the "whitelabel" error page of Spring with a custom one rendered through React. By default you cannot access the HTTP headers of the current page with Javascript so React never knows if it should show an error. I circumvented this by injecting a global JS var called `__CODEFREAK_ERROR` into the `index.html` that contains all the `ErrorProperties` from spring. In production this will be picked up by the React frontend and rendered into a standalone error page. For dev environments I introduced a placeholder `index.html` that will be replaced during build by the `deployFrontend` gradle task. The placeholder shows some information for devs how to access the React dev-server and the key-value pairs of `__CODEFREAK_ERROR`.

Some additional tweaks:
* `RequestRejectedException` will be returned to the client as status `400` instead of `500`
* Stacktraces are only exposed if in `DEV` profile
