### PR TITLE
Only allow upload of supported archive types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
   implementation 'javax.validation:validation-api:2.0.1.Final'
   implementation 'org.hibernate:hibernate-validator:7.0.0.Final'
   implementation 'com.google.guava:guava:30.1-jre'
+  implementation 'org.tukaani:xz:1.8'
   kapt 'org.springframework.boot:spring-boot-configuration-processor'
   runtimeOnly 'org.springframework.boot:spring-boot-devtools'
   runtimeOnly 'org.postgresql:postgresql'

--- a/client/src/components/FileImport.tsx
+++ b/client/src/components/FileImport.tsx
@@ -14,6 +14,7 @@ interface FileImportProps {
   onUpload: (files: File[]) => void
   importing: boolean
   onImport: (url: string) => void
+  acceptedTypes?: string[]
 }
 
 const FileImport: React.FC<FileImportProps> = props => {
@@ -49,6 +50,7 @@ const FileImport: React.FC<FileImportProps> = props => {
       <Col span={12}>
         <Dragger
           multiple
+          accept={props.acceptedTypes?.join(',')}
           showUploadList={false}
           beforeUpload={beforeUpload}
           disabled={uploading}

--- a/client/src/components/ImportAssignmentButton.tsx
+++ b/client/src/components/ImportAssignmentButton.tsx
@@ -8,6 +8,7 @@ import { UploadOutlined } from '@ant-design/icons'
 import { Button, Modal } from 'antd'
 import FileImport from './FileImport'
 import { useInlineErrorMessage } from '../hooks/useInlineErrorMessage'
+import { supportedArchiveExtensions } from '../services/file'
 
 interface ImportAssignmentButtonProps {
   onImportCompleted: (
@@ -77,18 +78,7 @@ const ImportAssignmentButton = (props: ImportAssignmentButtonProps) => {
           onUpload={onUpload}
           importing={importing}
           onImport={onImport}
-          acceptedTypes={[
-            '.zip',
-            '.tar',
-            '.gz',
-            '.xz',
-            '.Z',
-            '.bz2',
-            '.tbz2',
-            '.tgz',
-            '.txz',
-            '.jar'
-          ]}
+          acceptedTypes={supportedArchiveExtensions}
         />
       </Modal>
     </>

--- a/client/src/components/ImportAssignmentButton.tsx
+++ b/client/src/components/ImportAssignmentButton.tsx
@@ -77,6 +77,18 @@ const ImportAssignmentButton = (props: ImportAssignmentButtonProps) => {
           onUpload={onUpload}
           importing={importing}
           onImport={onImport}
+          acceptedTypes={[
+            '.zip',
+            '.tar',
+            '.gz',
+            '.xz',
+            '.Z',
+            '.bz2',
+            '.tbz2',
+            '.tgz',
+            '.txz',
+            '.jar'
+          ]}
         />
       </Modal>
     </>

--- a/client/src/components/ImportTasksButton.tsx
+++ b/client/src/components/ImportTasksButton.tsx
@@ -79,6 +79,18 @@ const ImportTasksButton = (props: ImportTasksButtonProps) => {
           onUpload={onUpload}
           importing={importing}
           onImport={onImport}
+          acceptedTypes={[
+            '.zip',
+            '.tar',
+            '.gz',
+            '.xz',
+            '.Z',
+            '.bz2',
+            '.tbz2',
+            '.tgz',
+            '.txz',
+            '.jar'
+          ]}
         />
       </Modal>
     </>

--- a/client/src/components/ImportTasksButton.tsx
+++ b/client/src/components/ImportTasksButton.tsx
@@ -8,6 +8,7 @@ import { UploadOutlined } from '@ant-design/icons'
 import { Alert, Button, Modal } from 'antd'
 import FileImport from './FileImport'
 import { useInlineErrorMessage } from '../hooks/useInlineErrorMessage'
+import { supportedArchiveExtensions } from '../services/file'
 
 interface ImportTasksButtonProps {
   onImportCompleted: (
@@ -79,18 +80,7 @@ const ImportTasksButton = (props: ImportTasksButtonProps) => {
           onUpload={onUpload}
           importing={importing}
           onImport={onImport}
-          acceptedTypes={[
-            '.zip',
-            '.tar',
-            '.gz',
-            '.xz',
-            '.Z',
-            '.bz2',
-            '.tbz2',
-            '.tgz',
-            '.txz',
-            '.jar'
-          ]}
+          acceptedTypes={supportedArchiveExtensions}
         />
       </Modal>
     </>

--- a/client/src/services/file.ts
+++ b/client/src/services/file.ts
@@ -31,3 +31,58 @@ export const sliceLines = (input: string, start?: number, end?: number) => {
   const startIndex = start ? Math.max(start - 1, 0) : undefined
   return split.slice(startIndex, end).join('\n')
 }
+
+/**
+ * Matches the given files with the accepted file extensions and returns the list of files with invalid extensions.
+ *
+ * @param fileNames The file names
+ * @param acceptedExtensions The accepted file extensions, e.g. [ '.zip' ]
+ */
+export const findFilesWithInvalidExtension = (
+  fileNames: string[],
+  acceptedExtensions: string[]
+) => {
+  const invalidFiles: string[] = []
+
+  fileNames.forEach(fileName => {
+    if (!validateFileExtension(fileName, acceptedExtensions)) {
+      invalidFiles.push(fileName)
+    }
+  })
+
+  return invalidFiles
+}
+
+/**
+ * Matches a file name against a list of accepted file extensions and returns whether the file has an accepted extension.
+ *
+ * @param fileName The file name
+ * @param acceptedExtensions The accepted file extensions, e.g. [ '.zip' ]
+ */
+const validateFileExtension = (
+  fileName: string,
+  acceptedExtensions: string[]
+) => {
+  const fileExtension = extractExtension(fileName)
+  let isFileExtensionValid = false
+
+  acceptedExtensions.forEach(extension => {
+    if (extension === fileExtension) {
+      isFileExtensionValid = true
+    }
+  })
+
+  return isFileExtensionValid
+}
+
+/**
+ * Extracts the extension from a file name.
+ * Returns an empty string if the file has no extension.
+ *
+ * @param fileName The file name
+ */
+const extractExtension = (fileName: string) => {
+  const extensionIndex = fileName.lastIndexOf('.')
+  // The index has to be greater than 0 because files can start with a '.' but have no extension
+  return extensionIndex > 0 ? fileName.substring(extensionIndex) : ''
+}

--- a/client/src/services/file.ts
+++ b/client/src/services/file.ts
@@ -86,3 +86,16 @@ const extractExtension = (fileName: string) => {
   // The index has to be greater than 0 because files can start with a '.' but have no extension
   return extensionIndex > 0 ? fileName.substring(extensionIndex) : ''
 }
+
+export const supportedArchiveExtensions = [
+  '.zip',
+  '.tar',
+  '.gz',
+  '.xz',
+  '.Z',
+  '.bz2',
+  '.tbz2',
+  '.tgz',
+  '.txz',
+  '.jar'
+]


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
It's possible to upload archive types which are not supported or even just a single `codefreak.yml` which results in unexpected behavior. By not accepting unsupported files it is clearer for the user what to do.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
