### PR TITLE
Fix access denied exception when fetching evaluation as student

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/graphql/api/EvaluationApi.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/graphql/api/EvaluationApi.kt
@@ -57,7 +57,6 @@ class EvaluationStepDefinitionDto(definition: EvaluationStepDefinition, ctx: Res
     objectMapper.writeValueAsString(definition.options)
   }
   val runner by lazy {
-    ctx.authorization.requireAuthority(Authority.ROLE_TEACHER)
     ctx.serviceAccess.getService(EvaluationService::class).getEvaluationRunner(runnerName).let { EvaluationRunnerDto(it) }
   }
   val timeout = definition.timeout


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
We use the `EvaluationStepDefinition.runner.stoppable` prop to determine if a runner is automated or not to display the "Running for…" information. `EvaluationStepDefinition.runner` was only accessible to teachers/admins. I don't think this is necessary as the plain runner information do not contain any sensitive data.
