### PR TITLE
Do not run GitRevisionPlugin and create standalone Define plugin

### DIFF
--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -1,32 +1,37 @@
-const { DefinePlugin } = require('webpack')
 const CracoAntDesignPlugin = require('craco-antd')
-const rawLoader = require('craco-raw-loader')
-const GitRevisionPlugin = require('git-revision-webpack-plugin')
+const CracoRawLoaderPlugin = require('craco-raw-loader')
 const CracoSvgReactLoaderPlugin = require('./craco/craco-svg-loader-plugin')
+const CracoDefinePlugin = require('./craco/craco-define-plugin')
+const GitRevisionPlugin = require('git-revision-webpack-plugin')
 
-const gitRevisionPlugin = new GitRevisionPlugin()
+/**
+ * Add globals to environment that expose build year and version/hash from Git
+ * via DefinePlugin
+ */
+const createBuildDefinitions = () => {
+  const gitRevisionPlugin = new GitRevisionPlugin()
+  return {
+    'process.env.BUILD_YEAR': JSON.stringify(new Date().getFullYear()),
+    'process.env.BUILD_VERSION': JSON.stringify(gitRevisionPlugin.version()),
+    'process.env.BUILD_HASH': JSON.stringify(gitRevisionPlugin.commithash())
+  }
+}
 
 module.exports = {
   plugins: [
     { plugin: CracoAntDesignPlugin },
-    { plugin: rawLoader, options: { test: /\.adoc$/ } },
+    { plugin: CracoRawLoaderPlugin, options: { test: /\.adoc$/ } },
     {
       plugin: CracoSvgReactLoaderPlugin,
       options: {
         exclude: /bootstrap-less\/fonts/ // prevent svg fonts from being processed
       }
+    },
+    {
+      plugin: CracoDefinePlugin,
+      options: {
+        definitions: [createBuildDefinitions]
+      }
     }
-  ],
-  webpack: {
-    plugins: [
-      new GitRevisionPlugin(),
-      new DefinePlugin({
-        'process.env.BUILD_YEAR': JSON.stringify(new Date().getFullYear()),
-        'process.env.BUILD_VERSION': JSON.stringify(
-          gitRevisionPlugin.version()
-        ),
-        'process.env.BUILD_HASH': JSON.stringify(gitRevisionPlugin.commithash())
-      })
-    ]
-  }
+  ]
 }

--- a/client/craco/craco-define-plugin.js
+++ b/client/craco/craco-define-plugin.js
@@ -1,0 +1,48 @@
+const { DefinePlugin } = require('webpack')
+
+/**
+ * Tiny wrapper around webpack's DefinePlugin
+ * Allows to supply multiple "definitions" as array of either objects or
+ * functions that return key-value-pairs of objects
+ *
+ * Example:
+ * {
+ *   plugins: [{
+ *    plugins: CracoDefinePlugin,
+ *    options: {
+ *      definitions: [
+ *        {
+ *          "process.env.TEST1": "123",
+ *        },
+ *        () => ({
+ *          "process.env.TEST2": "456",
+ *        })
+ *      ]
+ *    }
+ *   }]
+ * }
+ */
+module.exports = {
+  overrideWebpackConfig: ({ webpackConfig, pluginOptions }) => {
+    if (!pluginOptions.definitions) {
+      return webpackConfig
+    }
+
+    // merge all definitions into a flat object. Later values will take
+    // precedence over previous ones.
+    const definitions = pluginOptions.definitions.reduce((acc, value) => {
+      if (typeof value === 'function') return { ...acc, ...value() }
+      if (typeof value === 'object') return { ...acc, ...value }
+      throw `Invalid value type supplied for define plugin: ${typeof value}\n
+      Expected types are object or function.`
+    }, {})
+
+    const definePlugin = new DefinePlugin(definitions)
+
+    const { plugins, ...restWebpackConfig } = webpackConfig
+    return {
+      plugins: [...plugins, definePlugin],
+      ...restWebpackConfig
+    }
+  }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
We never used the files `VERSION` and `COMMITHASH` created by the `GitRevisionPlugin`. Instead we only used its API to define our globals `BULD_VERSION` and `BUILD_HASH`.
I also created a small wrapper around webpack's DefinePlugin so we only have Craco plugins in our craco config.
