### PR TITLE
Re-fetch assignment list on logout/login so the cache does not cause an endless reloading

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -32,46 +32,61 @@ import { noop } from './services/util'
 import { HideNavigationProvider } from './hooks/useHideNavigation'
 import LoadingIndicator from './components/LoadingIndicator'
 
-const App: React.FC<{ onUserChanged?: () => void }> = props => {
+interface AppProps {
+  /**
+   * Will be called immediately after either a login our logout mutation has been
+   * performed.
+   */
+  onUserChanged?: (type: 'login' | 'logout') => Promise<void>
+}
+
+const App: React.FC<AppProps> = props => {
   const onUserChanged = props.onUserChanged || noop
   const [
     authenticatedUser,
     setAuthenticatedUser
   ] = useState<AuthenticatedUser>()
   const timeOffset = useCalculatedServerTimeOffset()
-
+  const [loggingOut, setLoggingOut] = useState<boolean>(false)
   const { data: authResult, loading } = useGetAuthenticatedUserQuery({
     context: { disableGlobalErrorHandling: true },
     fetchPolicy: 'network-only'
   })
+  const [logoutMutation] = useLogoutMutation()
 
-  const [logout, { data: logoutSucceeded }] = useLogoutMutation()
-
+  // the user might already been authenticated. We query the backend for the
+  // current user and while the auth status is undefined we will show a spinner
   useEffect(() => {
     if (authResult !== undefined) {
       setAuthenticatedUser(authResult.me)
     }
   }, [authResult])
 
-  useEffect(() => {
-    if (logoutSucceeded) {
-      messageService.success('Successfully signed out. Goodbye 👋')
-      setAuthenticatedUser(undefined)
-      onUserChanged()
-    }
-  }, [logoutSucceeded, onUserChanged])
-
   if (loading || timeOffset === undefined) {
     return <LoadingIndicator />
   }
 
-  if (authenticatedUser === undefined) {
+  // this will show the login dialog while logout is in progress with all
+  // fields disabled. Otherwise the user would not get any feedback after
+  // clicking the logout button
+  if (loggingOut || authenticatedUser === undefined) {
     const onLogin = async (user: AuthenticatedUser) => {
+      await onUserChanged('login')
       messageService.success(`Welcome back, ${displayName(user)}!`)
-      await onUserChanged()
       setAuthenticatedUser(user)
     }
-    return <LoginPage onSuccessfulLogin={onLogin} />
+    return <LoginPage loggingOut={loggingOut} onSuccessfulLogin={onLogin} />
+  }
+
+  const logout = async () => {
+    // show the login dialog immediately after clicking logout. Both, the logout
+    // mutation and onUserChanged() may take some time to complete.
+    setLoggingOut(true)
+    await logoutMutation()
+    await onUserChanged('logout')
+    setAuthenticatedUser(undefined)
+    messageService.success('Successfully signed out. Goodbye 👋')
+    setLoggingOut(false)
   }
 
   const routes: MenuDataItem[] = []

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -66,10 +66,10 @@ const App: React.FC<{ onUserChanged?: () => void }> = props => {
   }
 
   if (authenticatedUser === undefined) {
-    const onLogin = (user: AuthenticatedUser) => {
+    const onLogin = async (user: AuthenticatedUser) => {
       messageService.success(`Welcome back, ${displayName(user)}!`)
+      await onUserChanged()
       setAuthenticatedUser(user)
-      onUserChanged()
     }
     return <LoginPage onSuccessfulLogin={onLogin} />
   }

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -25,9 +25,9 @@ const renderApp = () => {
     websocket.connect()
   }
 
-  const onUserChanged = () => {
+  const onUserChanged = async () => {
     resetWebsocket()
-    apolloClient.clearStore()
+    await apolloClient.clearStore()
   }
 
   return (

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -25,8 +25,13 @@ const renderApp = () => {
     websocket.connect()
   }
 
-  const onUserChanged = async () => {
-    resetWebsocket()
+  const onUserChanged = async (type: 'login' | 'logout') => {
+    // on logout the server will close the connection and apollo will reconnect
+    // automatically. On login we have to reconnect because we just received our
+    // cookie from the server and this will be passed to the server when reconnecting
+    if (type === 'login') {
+      resetWebsocket()
+    }
     await apolloClient.clearStore()
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
The query cache seems to cause an endless loading of the assignment list sometimes when loggin out and in again.
To stop this the assignment list should be re-fetched on login.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
