### PR TITLE
Fix database default values

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/entity/Evaluation.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/entity/Evaluation.kt
@@ -6,6 +6,7 @@ import javax.persistence.Entity
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.Transient
+import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.Type
 
@@ -20,6 +21,7 @@ class Evaluation(
   @Type(type = "image")
   var filesDigest: ByteArray,
 
+  @ColumnDefault("1970-01-01 00:00:00")
   var evaluationSettingsFrom: Instant
 ) : BaseEntity() {
   @OneToMany(mappedBy = "evaluation", cascade = [CascadeType.ALL], orphanRemoval = true)

--- a/src/main/kotlin/org/codefreak/codefreak/entity/EvaluationStep.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/entity/EvaluationStep.kt
@@ -10,6 +10,7 @@ import javax.persistence.FetchType
 import javax.persistence.Lob
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
+import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.Type
 
 /**
@@ -25,6 +26,7 @@ class EvaluationStep(
   var evaluation: Evaluation,
 
   @Enumerated(EnumType.STRING)
+  @ColumnDefault("'FINISHED'")
   var status: EvaluationStepStatus
 ) : BaseEntity() {
   @OneToMany(mappedBy = "evaluationStep", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])

--- a/src/main/resources/db/changelog-master.yaml
+++ b/src/main/resources/db/changelog-master.yaml
@@ -56,3 +56,6 @@ databaseChangeLog:
 - include:
     file: changelogs/20210125113533-add-evaluationstep-timestamps.yaml
     relativeToChangelogFile: true
+- include:
+    file: changelogs/20210215184015-evaluation-settings-from-default.yaml
+    relativeToChangelogFile: true

--- a/src/main/resources/db/changelogs/20210215184015-evaluation-settings-from-default.yaml
+++ b/src/main/resources/db/changelogs/20210215184015-evaluation-settings-from-default.yaml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+- changeSet:
+    id: 1613410830555-1
+    author: hkasch (generated)
+    changes:
+    - addDefaultValue:
+        columnDataType: timestamp
+        columnName: evaluation_settings_from
+        defaultValue: "1970-01-01 00:00:00"
+        tableName: evaluation


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
This fixes two issues with missing default values in DB:
* `EvaluationStep.status` did not have any default value defined in Kotlin so liquibase always generates a `dropDefaultValue` changeset 
* `Evaluation.evaluationSettingsFrom` had not any default value at all causing a `Parameter specified as non-null is null` exception  for existing DB entries during runtime

