### PR TITLE
Drop ENV variable and update README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following command will start the latest development version of Code FREAK ba
 
 ```shell script
 docker run -it --rm \
-    -eSPRING_PROFILES_ACTIVE=dev \
+    -e SPRING_PROFILES_ACTIVE=dev \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -p 8080:8080 \
     cfreak/codefreak:canary

--- a/README.md
+++ b/README.md
@@ -29,16 +29,20 @@ We currently only support installation via Docker. The image name is [`cfreak/co
 ### Try with Docker 🐋
 
 You can try out Code FREAK locally. The only requirement is a working installation of Docker on your computer.
+The following command will start the latest development version of Code FREAK based on the `master` branch.
 
 ```shell script
 docker run -it --rm \
+    -eSPRING_PROFILES_ACTIVE=dev \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -p 8080:8080 \
-    cfreak/codefreak
+    cfreak/codefreak:canary
 ```
 
 The UI is accessible at http://localhost:8080.
-Log in using `admin` and password `123`.
+Log in using `teacher` and password `123`.
+Additionally, the users `admin` and `student` are available with their corresponding roles and the same password `123`.
+Using the "dev" environment will seed the database with some example assignments and tasks.
 
 This will use you local Docker daemon for evaluation and IDE instances.
 

--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ jib {
     // set image build date to current timestamp
     creationTime = "USE_CURRENT_TIMESTAMP"
     environment = [
-      ENV: "prod",
+      // default active profile is "dev"
       SPRING_PROFILES_ACTIVE: "prod",
       SENTRY_ENVIRONMENT: "prod",
       SENTRY_RELEASE: project.version.toString()


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
Our Docker image had a variable "ENV" defined that had no purpose.
Additionally I updated the Docker quickstart instructions to use the `canary` tag and the `dev` profile and added information about all available users.