### PR TITLE
Remove deadline from seeded assignment

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/service/SeedDatabaseService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/SeedDatabaseService.kt
@@ -79,7 +79,7 @@ class SeedDatabaseService : ApplicationListener<ContextRefreshedEvent> {
       "Sample Assignment",
       teacher,
       openFrom = Instant.now(),
-      deadline = Instant.now().plusSeconds(60),
+      deadline = null,
       active = true
     )
     assignmentService.saveAssignment(assignmentWithAllTasks)


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
The deadline on the seeded assignment is annoying for two reasons:

1. It causes an automated evaluation which results in unexpected resource usage
2. For some reason I always pick this assignment to test things and suddenly it's closed :disappointed: 