### PR TITLE
Add env variables to commandline and junit runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * When creating an assignment users can now directly set the title and tasks (#787)
 * Create project directory in IDE container before extracting files
 * Add task template for C++
+* Expose environment variables with information about the answer and user for commandline and junit runner
 
 ### Changed
 * Time limit can be specified on assignments and not on individual tasks (#635)

--- a/docs/modules/for-teachers/pages/evaluation-types.adoc
+++ b/docs/modules/for-teachers/pages/evaluation-types.adoc
@@ -35,6 +35,9 @@ evaluation:
         - gradle test
 ----
 
+=== Environment Variables
+During evaluation of the answer the same dynamic environment variables as for the `commandline` runner ar available. See <<cli-environment-variables, Commandline Environment Variables>>.
+
 == [[codeclimate]] Static Code Analysis (`codeclimate`)
 The static code analysis runner is currently based on https://codeclimate.com/[Code Climate]. Code Climate is a very powerful and extensible tool that gives helpful insight on issues in source code.
 
@@ -84,6 +87,52 @@ evaluation:
       commands:
         - /usr/bin/test -d /home
 ----
+
+
+=== [[cli-environment-variables]] Environment Variables
+During evaluation of the answer the following environment variables are available
+
+
+|===
+|Variable Name |Example Value |Explanation
+
+|`CI`
+|`true`
+|The value is always "true". Indicates running in a CI environment.
+
+|`CODEFREAK_ANSWER_ID`
+|`3a7b9bb9-4efe-4435-9df3-89b1bf7c01ab`
+|UUID of the answer currently processing
+
+|`CODEFREAK_ASSIGNMENT_ID`
+|`d420f578-fb0c-4974-afbe-42ec5856ab3b`
+|UUID of the assignment currently processing. The variable might be empty if running in task-pool testing mode.
+
+|`CODEFREAK_SUBMISSION_ID`
+|`3a24a325-bb5a-4de8-bbe7-cd99ca02fa19`
+|UUID of the submission currently processing
+
+|`CODEFREAK_TASK_ID`
+|`6d476ae7-9d45-4153-9157-a046192c40dd`
+|UUID of the task currently processing
+
+|`CODEFREAK_USER_ID`
+|`aefa1307-f247-4440-b1b1-ccc37f6563b9`
+|UUID of the user the answer belongs to
+
+|`CODEFREAK_USER_FIRST_NAME`
+|Jane
+|First name of the user the answer belongs to
+
+|`CODEFREAK_USER_LAST_NAME`
+|Doe
+|Last name of the user this answer belongs to
+
+|`CODEFREAK_USER_USERNAME`
+|jane.doe@student.example.org
+|Username/mail address of the user this answer belongs to
+|===
+
 
 == [[comments]] Comments (`comments`)
 The comments runner is a placeholder currently. Comments are always possible and *don't* have to be enabled in configuration.

--- a/src/main/kotlin/org/codefreak/codefreak/entity/User.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/entity/User.kt
@@ -29,7 +29,6 @@ class User(private val username: String) : BaseEntity(), UserDetails, Credential
   var password: String? = null
     @JvmName("_getPassword") get
 
-  fun getDisplayName() = listOfNotNull(firstName, lastName).ifEmpty { listOf(username) }.joinToString(" ")
   override fun getUsername() = username
   override fun getPassword() = password
   override fun getAuthorities() = roles.flatMap { it.allGrantedAuthorities }.toMutableList()

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/runner/AbstractDockerRunner.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/runner/AbstractDockerRunner.kt
@@ -33,4 +33,20 @@ abstract class AbstractDockerRunner : StoppableEvaluationRunner {
       ContainerService.LABEL_PREFIX + "eval.runner" to getName(),
       ContainerService.LABEL_PREFIX + "eval.answer-id" to answer.id.toString()
   )
+
+  protected fun buildEnvVariables(answer: Answer): List<String> {
+    val submission = answer.submission
+    val user = submission.user
+    return listOf(
+        "CI=true",
+        "CODEFREAK_USER_USERNAME=${user.usernameCanonical}",
+        "CODEFREAK_USER_FIRST_NAME=${user.firstName}",
+        "CODEFREAK_USER_LAST_NAME=${user.lastName}",
+        "CODEFREAK_USER_ID=${user.id}",
+        "CODEFREAK_ANSWER_ID=${answer.id}",
+        "CODEFREAK_TASK_ID=${answer.task.id}",
+        "CODEFREAK_SUBMISSION_ID=${submission.id}",
+        "CODEFREAK_ASSIGNMENT_ID=${submission.assignment?.id ?: ""}"
+    )
+  }
 }

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/runner/CommandLineRunner.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/runner/CommandLineRunner.kt
@@ -72,7 +72,10 @@ class CommandLineRunner : AbstractDockerRunner() {
   ): List<ExecResult> {
     val containerId = containerService.createContainer(image) {
       doNothingAndKeepAlive()
-      containerConfig { workingDir(projectPath) }
+      containerConfig {
+        workingDir(projectPath)
+        env(buildEnvVariables(answer))
+      }
       labels += getContainerLabelMap(answer)
     }
     val outputs = mutableListOf<ExecResult>()


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
Like Travis, GitLab, etc. this will expose environment variables to the `junit` and `commandline` runner during tests.
This allows to differentiate between running code in IDE and CI and also to create individual tests like "Write your email address to stdout".

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
