### PR TITLE
Add a back-to-assignment button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Create project directory in IDE container before extracting files
 * Add task template for C++
 * Expose environment variables with information about the answer and user for commandline and junit runner
+* Add a button to the task page to get back to the assignment (#844)
 
 ### Changed
 * Time limit can be specified on assignments and not on individual tasks (#635)

--- a/client/package.json
+++ b/client/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@ant-design/pro-layout": "5.0.19",
     "@ant-design/icons": "4.5.0",
+    "@ant-design/pro-layout": "5.0.19",
     "@apollo/client": "3.3.11",
     "@codefreak/docs": "file:../docs",
     "@craco/craco": "6.1.1",

--- a/client/src/pages/task/TaskPage.tsx
+++ b/client/src/pages/task/TaskPage.tsx
@@ -45,7 +45,7 @@ import {
   useGetTaskQuery,
   useUpdateTaskMutation
 } from '../../services/codefreak-api'
-import { getEntityPath } from '../../services/entity-path'
+import { BASE_PATHS, getEntityPath } from '../../services/entity-path'
 import { messageService } from '../../services/message'
 import { unshorten } from '../../services/short-id'
 import { displayName } from '../../services/user'
@@ -271,9 +271,10 @@ const TaskPage: React.FC = () => {
   ].filter((it): it is React.ReactElement<TagType> => it !== undefined)
 
   const goToAssignment = () => {
-    if (assignment) {
-      history.push(getEntityPath(assignment))
-    }
+    const previousPath = assignment
+      ? getEntityPath(assignment)
+      : BASE_PATHS.Task + '/pool'
+    history.push(previousPath)
   }
 
   return (

--- a/client/src/pages/task/TaskPage.tsx
+++ b/client/src/pages/task/TaskPage.tsx
@@ -270,6 +270,12 @@ const TaskPage: React.FC = () => {
     renderTimeLimit()
   ].filter((it): it is React.ReactElement<TagType> => it !== undefined)
 
+  const goToAssignment = () => {
+    if (assignment) {
+      history.push(getEntityPath(assignment))
+    }
+  }
+
   return (
     <DifferentUserContext.Provider value={differentUser}>
       <SetTitle>{task.title}</SetTitle>
@@ -291,6 +297,7 @@ const TaskPage: React.FC = () => {
             {teacherControls} {buttons}
           </>
         }
+        onBack={goToAssignment}
       />
       <Switch>
         <Route exact path={path}>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
Add a button to the task page to get back to the assignment as a quick fix for students not finding back to the assignment.

## :link: Related Issues
* Fixes # (issue)

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
