### PR TITLE
Fix the back button in the teacher's submission view

### DIFF
--- a/client/src/pages/task/TaskPage.tsx
+++ b/client/src/pages/task/TaskPage.tsx
@@ -271,9 +271,16 @@ const TaskPage: React.FC = () => {
   ].filter((it): it is React.ReactElement<TagType> => it !== undefined)
 
   const goToAssignment = () => {
-    const previousPath = assignment
-      ? getEntityPath(assignment)
-      : BASE_PATHS.Task + '/pool'
+    let previousPath
+
+    if (assignment && differentUser) {
+      previousPath = getEntityPath(assignment) + '/submissions'
+    } else if (assignment) {
+      previousPath = getEntityPath(assignment)
+    } else {
+      previousPath = BASE_PATHS.Task + '/pool'
+    }
+
     history.push(previousPath)
   }
 

--- a/client/src/pages/task/TaskPage.tsx
+++ b/client/src/pages/task/TaskPage.tsx
@@ -1,12 +1,11 @@
 import { PageHeaderWrapper } from '@ant-design/pro-layout'
 import {
-  ArrowLeftOutlined,
   CloudOutlined,
   DashboardOutlined,
   FileTextOutlined,
   SolutionOutlined
 } from '@ant-design/icons'
-import { Button, Switch as AntSwitch, Tooltip } from 'antd'
+import { Switch as AntSwitch, Tooltip } from 'antd'
 import { TagType } from 'antd/es/tag'
 import moment from 'moment'
 import { createContext, useCallback } from 'react'
@@ -216,14 +215,8 @@ const TaskPage: React.FC = () => {
 
   let buttons
   if (differentUser && assignment) {
-    // Show "back to submissions" button for teachers
-    const onClick = () =>
-      history.push(getEntityPath(assignment) + '/submissions')
-    buttons = (
-      <Button icon={<ArrowLeftOutlined />} size="large" onClick={onClick}>
-        Back to submissions
-      </Button>
-    )
+    // no buttons in the teacher's submission view
+    buttons = null
   } else if (answer) {
     // regular buttons to work on task for students
     buttons = (


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
When a teacher is viewing a submission let the new back-to-assignment button actually go back to the submissions.
Also remove the old big "back to submissions" button since we have the new button now.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
