### PR TITLE
Handle network errors properly on client

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -23,11 +23,15 @@ const LoginPage: React.FC<LoginProps> = props => {
 
   const handleSubmit = async (values: Credentials) => {
     setLoading(true)
-    const { data } = await login({ variables: values })
-    if (data?.login) {
-      await onSuccessfulLogin(data.login.user)
+    try {
+      const { data } = await login({ variables: values })
+      if (data?.login) {
+        await onSuccessfulLogin(data.login.user)
+      }
+    } finally {
+      // get out of loading mode even if something goes wrong
+      setLoading(false)
     }
-    setLoading(false)
   }
 
   return (

--- a/client/src/services/codefreak-api.ts
+++ b/client/src/services/codefreak-api.ts
@@ -1,12 +1,29 @@
-import { GraphQLError } from 'graphql'
-import { ApolloClient, ApolloLink, InMemoryCache, split } from '@apollo/client'
-import { onError } from '@apollo/client/link/error'
+import {
+  ApolloClient,
+  ApolloLink,
+  InMemoryCache,
+  ServerError,
+  split
+} from '@apollo/client'
+import { ErrorHandler, ErrorResponse, onError } from '@apollo/client/link/error'
 import { messageService } from './message'
 import { getMainDefinition } from '@apollo/client/utilities'
 import { createUploadLink } from 'apollo-upload-client'
 import { WebSocketLink } from '@apollo/client/link/ws'
+import { GraphQLError } from 'graphql'
 
 export * from '../generated/graphql'
+
+const isNetworkError = (
+  error: any
+): error is Pick<ServerError, 'response' | 'statusCode' | 'message'> => {
+  return (
+    typeof error === 'object' &&
+    'response' in error &&
+    'statusCode' in error &&
+    'message' in error
+  )
+}
 
 export const extractErrorMessage = (error: {
   graphQLErrors?: ReadonlyArray<GraphQLError>
@@ -30,18 +47,43 @@ export const createApolloWsLink = () => {
   })
 }
 
+const extractErrorMessageFromResponse = (error: ErrorResponse) => {
+  const { graphQLErrors, networkError } = error
+  if (graphQLErrors !== undefined) {
+    return extractErrorMessage({ graphQLErrors })
+  }
+  if (isNetworkError(networkError)) {
+    const { statusCode, message } = networkError
+    return `Error ${statusCode}: ${message}`
+  }
+  return 'Something went wrong. Please try again.'
+}
+
+/**
+ * Global Apollo error handler that shows an error notification
+ * at the top of the screen.
+ * There is a bug (or feature?) in Apollo where this error handling is never
+ * applied to mutations:
+ * https://github.com/apollographql/apollo-client/issues/6070
+ *
+ * @param error
+ */
+const apolloErrorHandler: ErrorHandler = error => {
+  if (!error.operation.getContext().disableGlobalErrorHandling) {
+    // If not authenticated or session expired, reload page to show login dialog
+    const { networkError } = error
+    if (isNetworkError(networkError) && networkError.statusCode === 401) {
+      window.location.reload()
+      return
+    }
+    messageService.error(extractErrorMessageFromResponse(error))
+  }
+}
+
 export const createApolloClient = (wsLink: WebSocketLink) => {
   return new ApolloClient({
     link: ApolloLink.from([
-      onError(error => {
-        if (!error.operation.getContext().disableGlobalErrorHandling) {
-          // If not authenticated or session expired, reload page to show login dialog
-          if ((error as any).networkError?.extensions?.errorCode === '401') {
-            window.location.reload()
-          }
-          messageService.error(extractErrorMessage(error))
-        }
-      }),
+      onError(apolloErrorHandler),
       split(
         ({ query }) => {
           const definition = getMainDefinition(query)


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
Our global error handler only extracted errors from `graphQLErrors` property.
This PR now also handles `networkError` in case a connection to the backend is not possible.

