### PR TITLE
Add IDE presets to prefill ide.image and ide.cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Expose environment variables with information about the answer and user for commandline and junit runner
 * Add a button to the task page to get back to the assignment (#844)
 * Assignments show the dates they were created and last updated (#865)
+* Add IDE presets that will allow beta-testing of Breeze (#871)
 
 ### Changed
 * Time limit can be specified on assignments and not on individual tasks (#635)

--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -1,6 +1,7 @@
 const CracoAntDesignPlugin = require('craco-antd')
 const CracoSvgReactLoaderPlugin = require('./craco/craco-svg-loader-plugin')
 const CracoDefinePlugin = require('./craco/craco-define-plugin')
+const CracoYamlPlugin = require('./craco/craco-yaml-plugin')
 const GitRevisionPlugin = require('git-revision-webpack-plugin')
 
 /**
@@ -19,6 +20,7 @@ const createBuildDefinitions = () => {
 module.exports = {
   plugins: [
     { plugin: CracoAntDesignPlugin },
+    { plugin: CracoYamlPlugin },
     {
       plugin: CracoSvgReactLoaderPlugin,
       options: {

--- a/client/craco/craco-yaml-plugin.js
+++ b/client/craco/craco-yaml-plugin.js
@@ -1,0 +1,20 @@
+const { addBeforeLoader, loaderByName } = require('@craco/craco')
+
+module.exports = {
+  overrideWebpackConfig: ({ webpackConfig, pluginOptions }) => {
+    const yamlLoader = {
+      test: /\.ya?ml$/,
+      type: 'json',
+      use: [
+        {
+          loader: 'yaml-loader'
+        }
+      ],
+      ...pluginOptions
+    }
+
+    addBeforeLoader(webpackConfig, loaderByName('file-loader'), yamlLoader)
+
+    return webpackConfig
+  }
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@codefreak/codefreak",
-      "version": "0.1.0",
+      "version": "5.0.3",
       "dependencies": {
         "@ant-design/icons": "4.5.0",
         "@ant-design/pro-layout": "5.0.19",
@@ -67,7 +67,8 @@
         "tslint-react": "4.1.0",
         "typescript": "4.2.2",
         "use-persisted-state": "0.3.3",
-        "webpack": "4.44.2"
+        "webpack": "4.44.2",
+        "yaml-loader": "^0.6.0"
       }
     },
     "../docs": {
@@ -28744,6 +28745,50 @@
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
       "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
     },
+    "node_modules/yaml-loader": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.6.0.tgz",
+      "integrity": "sha512-1bNiLelumURyj+zvVHOv8Y3dpCri0F2S+DCcmps0pA1zWRLjS+FhZQg4o3aUUDYESh73+pKZNI18bj7stpReow==",
+      "dependencies": {
+        "loader-utils": "^1.4.0",
+        "yaml": "^1.8.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yaml-loader/node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/yaml-loader/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/yaml-loader/node_modules/loader-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -53031,6 +53076,40 @@
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
       "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
+    },
+    "yaml-loader": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.6.0.tgz",
+      "integrity": "sha512-1bNiLelumURyj+zvVHOv8Y3dpCri0F2S+DCcmps0pA1zWRLjS+FhZQg4o3aUUDYESh73+pKZNI18bj7stpReow==",
+      "requires": {
+        "loader-utils": "^1.4.0",
+        "yaml": "^1.8.3"
+      },
+      "dependencies": {
+        "emojis-list": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        }
+      }
     },
     "yargs": {
       "version": "15.4.1",

--- a/client/package.json
+++ b/client/package.json
@@ -62,7 +62,8 @@
     "tslint-react": "4.1.0",
     "typescript": "4.2.2",
     "use-persisted-state": "0.3.3",
-    "webpack": "4.44.2"
+    "webpack": "4.44.2",
+    "yaml-loader": "^0.6.0"
   },
   "scripts": {
     "start": "craco start",

--- a/client/src/components/IdeSettingsForm.tsx
+++ b/client/src/components/IdeSettingsForm.tsx
@@ -44,14 +44,9 @@ const renderPresetOptionGroups = () => {
 }
 
 const IdeSettingsForm: React.FC<IdeSettingsFormProps> = props => {
-  const { defaultValue, onChange } = props
+  const { defaultValue = {}, onChange } = props
   const { data: defaultIdeImage } = useSystemConfig('defaultIdeImage')
-  const [values, setValues] = useState<IdeSettingsModel>(
-    defaultValue || {
-      ideImage: undefined,
-      ideArguments: undefined
-    }
-  )
+  const [values, setValues] = useState<IdeSettingsModel>(defaultValue)
 
   const setValue = <K extends keyof IdeSettingsModel>(
     field: K

--- a/client/src/components/IdeSettingsForm.tsx
+++ b/client/src/components/IdeSettingsForm.tsx
@@ -1,0 +1,149 @@
+import React, { ChangeEventHandler, useState } from 'react'
+import { Button, Col, Form, Input, Row, Select } from 'antd'
+import CodefreakDocsLink from './CodefreakDocsLink'
+import useSystemConfig from '../hooks/useSystemConfig'
+import idePresets, { IdePreset } from '../data/ide-presets.yaml'
+
+export interface IdeSettingsModel {
+  ideImage?: string
+  ideArguments?: string
+}
+
+export interface IdeSettingsFormProps {
+  defaultValue?: IdeSettingsModel
+  onChange?: (newValues: IdeSettingsModel) => void
+}
+
+const renderPresetOptions = (
+  prefix: string,
+  group: Record<string, IdePreset>
+) => {
+  return Object.keys(group).map(presetKey => {
+    const { title } = group[presetKey]
+    const key = `${prefix}.${presetKey}`
+    return (
+      <Select.Option key={key} value={key}>
+        {title}
+      </Select.Option>
+    )
+  })
+}
+
+const renderPresetOptionGroups = () => {
+  return Object.keys(idePresets).map(groupKey => {
+    const { title, items } = idePresets[groupKey] as {
+      title?: string
+      items: Record<string, IdePreset>
+    }
+    return (
+      <Select.OptGroup key={groupKey} label={title}>
+        {renderPresetOptions(groupKey, items)}
+      </Select.OptGroup>
+    )
+  })
+}
+
+const IdeSettingsForm: React.FC<IdeSettingsFormProps> = props => {
+  const { defaultValue, onChange } = props
+  const { data: defaultIdeImage } = useSystemConfig('defaultIdeImage')
+  const [values, setValues] = useState<IdeSettingsModel>(
+    defaultValue || {
+      ideImage: undefined,
+      ideArguments: undefined
+    }
+  )
+
+  const setValue = <K extends keyof IdeSettingsModel>(
+    field: K
+  ): ChangeEventHandler<HTMLInputElement> => e => {
+    const newValues = {
+      ...values,
+      [field]: e.target.value
+    }
+    setValues(newValues)
+    onChange?.(newValues)
+  }
+
+  const onPresetApply = (formValues: { preset: string }) => {
+    const [groupKey, presetKey] = formValues.preset.split('.')
+    const group = idePresets[groupKey]
+    if (group.items.hasOwnProperty(presetKey)) {
+      const { title, ...newValues } = group.items[presetKey]
+      setValues(newValues)
+      onChange?.(newValues)
+    }
+  }
+
+  return (
+    <Row gutter={16}>
+      <Col span={8}>
+        <h3>IDE Presets</h3>
+        <p>
+          You can select a preset from the list below which will fill your
+          "Image" and "CMD" fields with some sensible presets for the selected
+          purpose. Language-specific presets are meant to be used with their
+          corresponding Task templates (e.g. Java expects its main file at{' '}
+          <code>src/main/java/Main.java</code>).
+        </p>
+        <Form onFinish={onPresetApply}>
+          <Form.Item name="preset">
+            <Select defaultActiveFirstOption style={{ width: 400 }}>
+              {renderPresetOptionGroups()}
+            </Select>
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit">
+              Apply IDE preset
+            </Button>
+          </Form.Item>
+        </Form>
+      </Col>
+      <Col span={8}>
+        <h3>Image</h3>
+        <p>
+          Optionally, you can specify a custom Docker image for the student
+          Online IDE. You will most likely <em>not</em> need this! Read more
+          about custom IDE images{' '}
+          <CodefreakDocsLink category="for-teachers" page="ide">
+            here
+          </CodefreakDocsLink>
+          .
+        </p>
+        <p>
+          Leave blank to use the default image <code>{defaultIdeImage}</code>.
+        </p>
+        <Input
+          style={{
+            maxWidth: 400
+          }}
+          value={values.ideImage}
+          placeholder="e.g. foo/bar:latest"
+          allowClear
+          onChange={setValue('ideImage')}
+        />
+      </Col>
+      <Col span={8}>
+        <h3>CMD / Arguments</h3>
+        <p>
+          You can customize the CMD on the container to alter either the
+          container CMD or pass additional arguments to the container. Only use
+          this if you know what you are doing.
+          <br />
+          <strong>Warning:</strong> These values are NOT parameters for{' '}
+          <code>docker run</code>!
+        </p>
+        <Input
+          style={{
+            maxWidth: 400
+          }}
+          value={values.ideArguments}
+          placeholder="--option=value --verbose"
+          allowClear
+          onChange={setValue('ideArguments')}
+        />
+      </Col>
+    </Row>
+  )
+}
+
+export default IdeSettingsForm

--- a/client/src/data/ide-presets.yaml
+++ b/client/src/data/ide-presets.yaml
@@ -1,0 +1,74 @@
+vscode:
+  title: Visual Studio Code
+  items:
+    default:
+      title: Default
+      ideImage: ''
+      ideArguments: ''
+    canary:
+      title: Latest unstable IDE release
+      ideImage: cfreak/ide:canary
+      ideArguments: ''
+
+breeze:
+  title: Breeze (Simple IDE – Alpha Test)
+  items:
+    generic:
+      title: Generic (Ubuntu 20.04)
+      ideImage: cfreak/breeze
+      ideArguments: >-
+        --image ubuntu:20.04
+    python2:
+      title: Python 2
+      ideImage: cfreak/breeze
+      ideArguments: >-
+        --image python:2
+        --main-file main.py
+        --run-cmd 'python2 main.py'
+    python3:
+      title: Python 3
+      ideImage: cfreak/breeze
+      ideArguments: >-
+        --image python:3
+        --main-file main.py
+        --run-cmd 'python3 main.py'
+    jdk8:
+      title: Java 8 (OpenJDK 8 + Gradle 6.8)
+      ideImage: cfreak/breeze
+      ideArguments: >-
+        --image gradle:6.8-jdk8
+        --enable-network true
+        --memory 256m
+        --main-file src/main/java/Main.java
+        --run-cmd 'gradle run'
+    jdk12:
+      title: Java 15 (OpenJDK 15 + Gradle 6.8)
+      ideImage: cfreak/breeze
+      ideArguments: >-
+        --image gradle:6.8-jdk15
+        --enable-network true
+        --memory 256m
+        --main-file src/main/java/Main.java
+        --run-cmd 'gradle run'
+    node-14:
+      title: JavaScript (NodeJS 14.16 LTS)
+      ideImage: cfreak/breeze
+      ideArguments: >-
+        --image node:14.16
+        --main-file src/index.js
+        --run-cmd 'node src/index.js'
+    cmake:
+      title: CMake
+      ideImage: cfreak/breeze
+      ideArguments: >-
+        --image rikorose/gcc-cmake
+        --main-file src/main.cpp
+        --run-cmd 'sh -c"cmake . -B build && cd build && make && src/ExampleProject_run"'
+    csharp:
+      title: C# (.NET Core 3.1)
+      ideImage: cfreak/breeze
+      ideArguments: >-
+        --image mcr.microsoft.com/dotnet/core/sdk:3.1
+        --main-file src/AddFunction/AddFunction.cs
+        --enable-network true
+        --run-cmd 'dotnet run --project src/AddFunction'

--- a/client/src/data/ide-presets.yaml.d.ts
+++ b/client/src/data/ide-presets.yaml.d.ts
@@ -1,0 +1,16 @@
+export interface IdePreset {
+  title: string
+  ideImage: string
+  ideArguments: string
+}
+
+export interface IdePresetGroup {
+  title?: string
+  items: Record<string, IdePreset>
+}
+
+const PresetGroups: {
+  [key: string]: IdePresetGroup
+}
+
+export default PresetGroups


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
Add a dropdown to the UI that will fill `ide.image` and `ide.cmd` with some language-specific values.
Currently, this is needed for our Breeze alpha-testing. In addition I also added an option to use the `cfreak/ide:canary` image.

The Java template makes use of the Gradle application plugin which is not installed in our Java template atm.
I will provide an additional PR to the Java template that fixes this.

![image](https://user-images.githubusercontent.com/2829004/110831337-6cfc9880-829a-11eb-98c1-0b1dd795b298.png)

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
