### PR TITLE
Handle status codes embedded in graphql errors properly

### DIFF
--- a/client/src/components/LaunchIdeSteps.tsx
+++ b/client/src/components/LaunchIdeSteps.tsx
@@ -5,7 +5,7 @@ import {
   useIsIdeLiveLazyQuery,
   useStartIdeMutation
 } from '../generated/graphql'
-import { extractErrorMessage } from '../services/codefreak-api'
+import { getErrorMessageFromApolloError } from '../services/codefreak-api'
 import {
   CloudOutlined,
   ForwardOutlined,
@@ -26,7 +26,7 @@ const LaunchIdeSteps: React.FC<{
 
   const [startIde] = useStartIdeMutation({
     variables: { type, id },
-    onError: e => setError(extractErrorMessage(e))
+    onError: e => setError(getErrorMessageFromApolloError(e))
   })
   const [checkIsIdeLive, { data, loading }] = useIsIdeLiveLazyQuery({
     variables: { type, id },

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -19,10 +19,13 @@ interface LoginProps {
 const LoginPage: React.FC<LoginProps> = props => {
   const { onSuccessfulLogin, loggingOut } = props
   const [loading, setLoading] = useState<boolean>(false)
-  const [login] = useLoginMutation()
+  const [login] = useLoginMutation({
+    errorPolicy: 'ignore' // prevents unhandled rejection errors
+  })
 
   const handleSubmit = async (values: Credentials) => {
     setLoading(true)
+    // errors during login are shown by our global error handling
     try {
       const { data } = await login({ variables: values })
       if (data?.login) {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
The improved error handling did not respect http errors that were embedded in graphqErrors.
These errors are delivered via network status 200 OK.
This caused the login-reload to not work as expected. 

Additionally this fixes unhandled rejection errors during login.