### PR TITLE
Fix comment handling

### DIFF
--- a/client/src/components/EvaluationStatusTracker.tsx
+++ b/client/src/components/EvaluationStatusTracker.tsx
@@ -30,6 +30,7 @@ const EvaluationStatusTracker: React.FC<EvaluationStatusTrackerProps> = props =>
         setStep(2)
         break
       case EvaluationStepStatus.Finished:
+      case EvaluationStepStatus.Canceled:
         setStep(3)
         break
     }

--- a/client/src/components/EvaluationStepPanel.tsx
+++ b/client/src/components/EvaluationStepPanel.tsx
@@ -117,7 +117,11 @@ export const EvaluationStepPanel: React.FC<EvaluationStepPanelProps> = props => 
   }
 
   if (!body) {
-    body = <Empty />
+    body = (
+      <div style={{ padding: '20px 0' }}>
+        <Empty description="This step has not been executed, yet." />
+      </div>
+    )
   }
 
   return (

--- a/client/src/components/FeedbackIcon.tsx
+++ b/client/src/components/FeedbackIcon.tsx
@@ -11,7 +11,7 @@ interface FeedbackIconProps {
 const FeedbackIcon: React.FC<FeedbackIconProps> = props => {
   const { status, severity } = props
 
-  if (status === FeedbackStatus.Failed && severity) {
+  if (severity) {
     return <FeedbackSeverityIcon severity={severity} />
   }
   if (status) {

--- a/client/src/components/code/ReviewComment.tsx
+++ b/client/src/components/code/ReviewComment.tsx
@@ -6,18 +6,27 @@ import { FeedbackSeverity } from '../../generated/graphql'
 import useAuthenticatedUser from '../../hooks/useAuthenticatedUser'
 import Avatar from '../user/Avatar'
 import { FormProps } from 'antd/es/form'
+import FeedbackSeverityIcon from '../FeedbackSeverityIcon'
+
+// these are ordered by increasing severity
+const FeedbackSeverityOptions: Record<FeedbackSeverity, string> = {
+  [FeedbackSeverity.Info]: 'Info',
+  [FeedbackSeverity.Minor]: 'Minor',
+  [FeedbackSeverity.Major]: 'Major',
+  [FeedbackSeverity.Critical]: 'Critical'
+}
 
 const renderSeveritySelect = () => {
   return (
     <Select
       style={{ width: '250px' }}
       placeholder="Select a severity"
-      allowClear
+      defaultValue={FeedbackSeverity.Info}
     >
-      {Object.entries(FeedbackSeverity).map(([value, key]) => {
+      {Object.entries(FeedbackSeverityOptions).map(([key, value]) => {
         return (
           <Select.Option key={key} value={key}>
-            {value}
+            <FeedbackSeverityIcon severity={key as FeedbackSeverity} /> {value}
           </Select.Option>
         )
       })}
@@ -97,7 +106,7 @@ const ReviewCommentForm: React.FC<ReviewCommentFormProps> = props => {
             </Form.Item>
             <Row>
               <Col span={12}>
-                <Form.Item hasFeedback name="severity">
+                <Form.Item hasFeedback name="severity" label="Severity">
                   {renderSeveritySelect()}
                 </Form.Item>
               </Col>

--- a/src/main/kotlin/org/codefreak/codefreak/entity/EvaluationStep.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/entity/EvaluationStep.kt
@@ -54,4 +54,16 @@ class EvaluationStep(
   }
 
   fun addAllFeedback(feedbackList: List<Feedback>) = feedbackList.forEach(this::addFeedback)
+
+  /**
+   * Reset a step for re-evaluation
+   */
+  fun reset() {
+    status = EvaluationStepStatus.PENDING
+    result = null
+    queuedAt = null
+    finishedAt = null
+    summary = null
+    feedback.removeAll(feedback)
+  }
 }

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationQueueCleaner.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationQueueCleaner.kt
@@ -30,7 +30,7 @@ class EvaluationQueueCleaner {
   private lateinit var evaluationQueue: EvaluationQueue
 
   @Autowired
-  private lateinit var evaluationService: EvaluationService
+  private lateinit var runnerService: EvaluationRunnerService
 
   @Autowired
   private lateinit var evaluationStepService: EvaluationStepService
@@ -55,7 +55,7 @@ class EvaluationQueueCleaner {
           // if the step still exist in our database stop the existing evaluation runner and reschedule the single step
           try {
             val evaluationStep = evaluationStepService.getEvaluationStep(stepId)
-            evaluationService.stopEvaluationStep(evaluationStep)
+            runnerService.stopAnswerEvaluation(evaluationStep.definition.runnerName, evaluationStep.evaluation.answer)
             evaluationQueue.insert(evaluationStep)
             log.info("Rescheduled evaluation step $stepId")
           } catch (e: EntityNotFoundException) {

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationRunnerService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationRunnerService.kt
@@ -1,0 +1,58 @@
+package org.codefreak.codefreak.service.evaluation
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SpecVersion
+import org.codefreak.codefreak.entity.Answer
+import org.codefreak.codefreak.entity.EvaluationStepDefinition
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class EvaluationRunnerService {
+
+  @Autowired
+  private lateinit var objectMapper: ObjectMapper
+
+  @Autowired
+  private lateinit var runners: List<EvaluationRunner>
+
+  private val runnersByName by lazy { runners.map { it.getName() to it }.toMap() }
+
+  fun getEvaluationRunner(name: String): EvaluationRunner = runnersByName[name]
+      ?: throw IllegalArgumentException("Evaluation runner '$name' not found")
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getAllRunners() = runners
+
+  /**
+   * Returns the default options for the given evaluation runner
+   */
+  fun getDefaultOptions(runnerName: String) = getEvaluationRunner(runnerName).getDefaultOptions()
+
+  fun isAutomated(runnerName: String): Boolean {
+    return getEvaluationRunner(runnerName) is StoppableEvaluationRunner
+  }
+
+  fun validateRunnerOptions(definition: EvaluationStepDefinition) {
+    val runner = getEvaluationRunner(definition.runnerName)
+    val schema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V6).getSchema(runner.getOptionsSchema())
+    val errors = schema.validate(objectMapper.valueToTree(definition.options))
+    require(errors.isEmpty()) { "Runner options for ${definition.runnerName} are invalid: \n" + errors.joinToString("\n") { it.message } }
+  }
+
+  @Transactional(readOnly = true)
+  fun stopAnswerEvaluation(runnerName: String, answer: Answer) {
+      val runner = getEvaluationRunner(runnerName)
+      if (runner is StoppableEvaluationRunner) {
+        runner.stop(answer)
+      } else {
+        log.warn("Cannot stop evaluation of runner ${runner.getName()}")
+      }
+  }
+}

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
@@ -200,10 +200,6 @@ class EvaluationService : BaseService() {
     if (evaluation.evaluationSteps.any { stepService.stepNeedsExecution(it) }) {
       return false
     }
-    // allow to re-run if any of the steps errored
-    if (evaluation.stepsResultSummary === EvaluationStepResult.ERRORED) {
-      return false
-    }
     return true
   }
 

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
@@ -1,21 +1,16 @@
 package org.codefreak.codefreak.service.evaluation
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.networknt.schema.JsonSchemaFactory
-import com.networknt.schema.SpecVersion
 import java.time.Instant
 import java.util.UUID
 import org.codefreak.codefreak.entity.Answer
 import org.codefreak.codefreak.entity.Assignment
 import org.codefreak.codefreak.entity.AssignmentStatus
 import org.codefreak.codefreak.entity.Evaluation
-import org.codefreak.codefreak.entity.EvaluationStep
 import org.codefreak.codefreak.entity.EvaluationStepDefinition
 import org.codefreak.codefreak.entity.EvaluationStepResult
 import org.codefreak.codefreak.entity.EvaluationStepStatus
 import org.codefreak.codefreak.entity.Feedback
 import org.codefreak.codefreak.entity.Task
-import org.codefreak.codefreak.entity.User
 import org.codefreak.codefreak.repository.EvaluationRepository
 import org.codefreak.codefreak.repository.EvaluationStepDefinitionRepository
 import org.codefreak.codefreak.repository.TaskRepository
@@ -23,6 +18,7 @@ import org.codefreak.codefreak.service.AssignmentStatusChangedEvent
 import org.codefreak.codefreak.service.BaseService
 import org.codefreak.codefreak.service.EntityNotFoundException
 import org.codefreak.codefreak.service.EvaluationStatusUpdatedEvent
+import org.codefreak.codefreak.service.EvaluationStepStatusUpdatedEvent
 import org.codefreak.codefreak.service.IdeService
 import org.codefreak.codefreak.service.SubmissionDeadlineReachedEvent
 import org.codefreak.codefreak.service.SubmissionService
@@ -65,21 +61,15 @@ class EvaluationService : BaseService() {
   private lateinit var evaluationQueue: EvaluationQueue
 
   @Autowired
-  private lateinit var runners: List<EvaluationRunner>
+  private lateinit var eventPublisher: ApplicationEventPublisher
 
   @Autowired
-  private lateinit var eventPublisher: ApplicationEventPublisher
+  private lateinit var runnerService: EvaluationRunnerService
 
   @Autowired
   private lateinit var evaluationStepDefinitionRepository: EvaluationStepDefinitionRepository
 
-  private val runnersByName by lazy { runners.map { it.getName() to it }.toMap() }
-
   private val log = LoggerFactory.getLogger(this::class.java)
-
-  companion object {
-    private val objectMapper = ObjectMapper()
-  }
 
   @Transactional
   fun startAssignmentEvaluation(assignmentId: UUID): List<Evaluation> {
@@ -101,20 +91,17 @@ class EvaluationService : BaseService() {
     ideService.saveAnswerFiles(answer, forceSaveFiles)
     check(!isEvaluationUpToDate(answer)) { "Evaluation is up to date." }
     check(!isEvaluationScheduled(answer.id)) { "Evaluation is already scheduled." }
-    val evaluation = createPendingEvaluation(answer)
-    evaluationQueue.insert(evaluation)
-    return evaluation
-  }
-
-  private fun createPendingEvaluation(answer: Answer): Evaluation {
     val digest = fileService.getCollectionMd5Digest(answer.id)
-    val evaluation = getOrCreateValidEvaluationByDigest(answer, digest)
-    answer.task.evaluationStepDefinitions.filter { it.active }.forEach {
-      stepService.addPendingEvaluationStep(evaluation, it)
-    }
-    return saveEvaluation(evaluation).also {
-      eventPublisher.publishEvent(EvaluationStatusUpdatedEvent(evaluation, evaluation.stepStatusSummary))
-    }
+    val evaluation = getOrCreateEvaluationByDigest(answer, digest)
+
+    // schedule all non-finished steps for automated evaluation
+    evaluation.evaluationSteps
+        .filter { stepService.stepNeedsExecution(it) }
+        .forEach {
+          it.reset()
+          evaluationQueue.insert(it)
+        }
+    return evaluation
   }
 
   fun getLatestEvaluation(answerId: UUID) = evaluationRepository.findFirstByAnswerIdOrderByCreatedAtDesc(answerId)
@@ -131,10 +118,10 @@ class EvaluationService : BaseService() {
     return getLatestEvaluation(answerId).map { it.stepStatusSummary }.orNull()
   }
 
-  fun getOrCreateValidEvaluationByDigest(answer: Answer, digest: ByteArray): Evaluation {
+  fun getOrCreateEvaluationByDigest(answer: Answer, digest: ByteArray): Evaluation {
     return evaluationRepository.findFirstByAnswerIdAndFilesDigestOrderByCreatedAtDesc(answer.id, digest)
-        .map { if (it.evaluationSettingsFrom != answer.task.evaluationSettingsChangedAt) createEvaluation(answer) else it }
-        .orElseGet { createEvaluation(answer) }
+        .map { if (it.evaluationSettingsFrom != answer.task.evaluationSettingsChangedAt) createEvaluation(answer, digest) else it }
+        .orElseGet { createEvaluation(answer, digest) }
   }
 
   @Transactional
@@ -150,56 +137,51 @@ class EvaluationService : BaseService() {
     assignment.tasks.forEach(this::invalidateEvaluations)
   }
 
-  fun createEvaluation(answer: Answer): Evaluation {
-    return saveEvaluation(
-        Evaluation(
-            answer,
-            fileService.getCollectionMd5Digest(answer.id),
-            answer.task.evaluationSettingsChangedAt
-        )
+  /**
+   * Create a fresh evaluation for the given answer + digest combination.
+   * All steps are in a pending state
+   */
+  @Transactional
+  fun createEvaluation(answer: Answer, filesDigest: ByteArray): Evaluation {
+    val evaluation = Evaluation(
+        answer,
+        filesDigest,
+        answer.task.evaluationSettingsChangedAt
     )
+    // add all steps as "pending" to the evaluation
+    answer.task.evaluationStepDefinitions
+        .filter { it.active }
+        .forEach { stepService.addStepToEvaluation(evaluation, it) }
+    return saveEvaluation(evaluation).also {
+      eventPublisher.publishEvent(EvaluationStatusUpdatedEvent(it, it.stepStatusSummary))
+    }
   }
 
   fun saveEvaluation(evaluation: Evaluation) = evaluationRepository.save(evaluation)
 
-  fun createCommentFeedback(author: User, comment: String): Feedback {
-    // use the first 10 words of the first line or max. 100 chars as summary
-    var summary = comment.trim().replace("((?:[^ \\n]+ ?){0,10})".toRegex(), "$1").trim()
-    if (summary.length > 100) {
-      summary = summary.substring(0..100) + "..."
-    }
-    return Feedback(summary).apply {
-      longDescription = comment
-      this.author = author
-    }
-  }
-
-  @Transactional(readOnly = true)
-  fun stopEvaluationStep(evaluationStep: EvaluationStep) {
-    val runnerName = evaluationStep.definition.runnerName
-    val answer = evaluationStep.evaluation.answer
-    val runner = getEvaluationRunner(runnerName)
-    if (runner is StoppableEvaluationRunner) {
-      runner.stop(answer)
-    } else {
-      log.warn("Cannot stop evaluation of runner ${runner.getName()}")
-    }
-  }
-
+  @Transactional
   fun addCommentFeedback(answer: Answer, digest: ByteArray, feedback: Feedback): Feedback {
     // find out if evaluation has a comment step definition
     val stepDefinition = answer.task.evaluationStepDefinitions.find { it.runnerName == CommentRunner.RUNNER_NAME }
         ?: throw IllegalArgumentException("Task has no 'comments' evaluation step")
-    val evaluation = getOrCreateValidEvaluationByDigest(answer, digest)
-
-    // either take existing comments step on evaluation or create a new one
+    val evaluation = getOrCreateEvaluationByDigest(answer, digest)
     val evaluationStep = evaluation.evaluationSteps.find { it.definition == stepDefinition }
-        ?: EvaluationStep(stepDefinition, evaluation, EvaluationStepStatus.FINISHED).also {
-          evaluation.addStep(it)
-        }
-
+        ?: throw RuntimeException("Evaluation does not contain a 'comments' step")
     evaluationStep.addFeedback(feedback)
+
+    // mark this evaluation step as "finished" which means "teacher evaluated this answer manually"
+    evaluationStep.status = EvaluationStepStatus.FINISHED
+    evaluationStep.finishedAt = Instant.now()
+    // if there is any failed feedback the overall step result is "failed"
+    evaluationStep.result = when {
+      evaluationStep.feedback.any { it.isFailed } -> EvaluationStepResult.FAILED
+      else -> EvaluationStepResult.SUCCESS
+    }
     saveEvaluation(evaluation)
+
+    // there is no real definition of "done" for comments, so we trigger a FINISHED event
+    // each time a new comment is added to this answer
+    eventPublisher.publishEvent(EvaluationStepStatusUpdatedEvent(evaluationStep, EvaluationStepStatus.FINISHED))
     return feedback
   }
 
@@ -214,8 +196,8 @@ class EvaluationService : BaseService() {
     if (!evaluation.filesDigest.contentEquals(fileService.getCollectionMd5Digest(answer.id))) {
       return false
     }
-    // check if all evaluation steps have been run
-    if (answer.task.evaluationStepDefinitions.size != evaluation.evaluationSteps.size) {
+    // check if any step needs execution
+    if (evaluation.evaluationSteps.any { stepService.stepNeedsExecution(it) }) {
       return false
     }
     // allow to re-run if any of the steps errored
@@ -224,16 +206,6 @@ class EvaluationService : BaseService() {
     }
     return true
   }
-
-  fun getEvaluationRunner(name: String): EvaluationRunner = runnersByName[name]
-      ?: throw IllegalArgumentException("Evaluation runner '$name' not found")
-
-  fun getAllEvaluationRunners() = runners
-
-  /**
-   * Returns the default options for the given evaluation runner
-   */
-  fun getDefaultOptions(runnerName: String) = getEvaluationRunner(runnerName).getDefaultOptions()
 
   fun getEvaluation(evaluationId: UUID): Evaluation {
     return evaluationRepository.findById(evaluationId).orElseThrow { EntityNotFoundException("Evaluation not found") }
@@ -286,13 +258,6 @@ class EvaluationService : BaseService() {
     evaluationStepDefinitionRepository.delete(evaluationStepDefinition)
   }
 
-  fun validateRunnerOptions(definition: EvaluationStepDefinition) {
-    val runner = getEvaluationRunner(definition.runnerName)
-    val schema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V6).getSchema(runner.getOptionsSchema())
-    val errors = schema.validate(objectMapper.valueToTree(definition.options))
-    require(errors.isEmpty()) { "Runner options for ${definition.runnerName} are invalid: \n" + errors.joinToString("\n") { it.message } }
-  }
-
   @Transactional
   fun updateEvaluationStepDefinition(evaluationStepDefinition: EvaluationStepDefinition, title: String?, active: Boolean?, timeout: Long?, options: Map<String, Any>?): EvaluationStepDefinition {
     title?.let {
@@ -305,7 +270,7 @@ class EvaluationService : BaseService() {
       evaluationStepDefinition.options = it
     }
     evaluationStepDefinition.timeout = timeout
-    validateRunnerOptions(evaluationStepDefinition)
+    runnerService.validateRunnerOptions(evaluationStepDefinition)
     saveEvaluationStepDefinition(evaluationStepDefinition)
     taskService.invalidateLatestEvaluations(evaluationStepDefinition.task)
 

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepProcessor.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepProcessor.kt
@@ -24,7 +24,10 @@ class EvaluationStepProcessor : ItemProcessor<EvaluationStep, EvaluationStep?> {
   private lateinit var taskExecutor: AsyncTaskExecutor
 
   @Autowired
-  private lateinit var evaluationService: EvaluationService
+  private lateinit var evaluationStepService: EvaluationStepService
+
+  @Autowired
+  private lateinit var runnerService: EvaluationRunnerService
 
   @Value("#{@config.evaluation.defaultTimeout}")
   private var defaultTimeout: Long = 0L
@@ -38,7 +41,7 @@ class EvaluationStepProcessor : ItemProcessor<EvaluationStep, EvaluationStep?> {
     val stepDefinition = evaluationStep.definition
     val runnerName = stepDefinition.runnerName
     try {
-      val runner = evaluationService.getEvaluationRunner(runnerName)
+      val runner = runnerService.getEvaluationRunner(runnerName)
       val feedbackList = try {
         runEvaluation(runner, evaluationStep)
       } catch (e: InterruptedException) {
@@ -89,7 +92,7 @@ class EvaluationStepProcessor : ItemProcessor<EvaluationStep, EvaluationStep?> {
       }
     } catch (e: TimeoutException) {
       log.info("Timeout for evaluation step $runnerName of answer ${answer.id} occurred after ${timeout}sec")
-      evaluationService.stopEvaluationStep(step)
+      runnerService.stopAnswerEvaluation(runnerName, answer)
       throw EvaluationStepException("Evaluation timed out after $timeout seconds",
           result = EvaluationStepResult.ERRORED,
           status = EvaluationStepStatus.CANCELED

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepService.kt
@@ -4,6 +4,7 @@ import java.util.UUID
 import org.codefreak.codefreak.entity.Evaluation
 import org.codefreak.codefreak.entity.EvaluationStep
 import org.codefreak.codefreak.entity.EvaluationStepDefinition
+import org.codefreak.codefreak.entity.EvaluationStepResult
 import org.codefreak.codefreak.entity.EvaluationStepStatus
 import org.codefreak.codefreak.repository.EvaluationStepRepository
 import org.codefreak.codefreak.service.EntityNotFoundException
@@ -23,10 +24,24 @@ class EvaluationStepService {
   @Autowired
   private lateinit var stepRepository: EvaluationStepRepository
 
+  @Autowired
+  private lateinit var runnerService: EvaluationRunnerService
+
   fun getEvaluationStep(stepId: UUID): EvaluationStep {
     return stepRepository.findById(stepId).orElseThrow {
       EntityNotFoundException("EvaluationStep $stepId could not be found")
     }
+  }
+
+  /**
+   * Determine if an evaluation step has to be executed by a runner
+   */
+  fun stepNeedsExecution(step: EvaluationStep): Boolean {
+    if (!runnerService.isAutomated(step.definition.runnerName)) {
+      return false
+    }
+    // non-finished steps or errored steps can be executed again
+    return step.status != EvaluationStepStatus.FINISHED || step.result === EvaluationStepResult.ERRORED
   }
 
   @Transactional
@@ -48,9 +63,10 @@ class EvaluationStepService {
   }
 
   /**
-   * Get the existing evaluation step from the evaluation or create a new one
+   * Add a new evaluation step to the evaluation based on a given definition.
+   * If a step with the same definition already exists, it will be replaced.
    */
-  fun addPendingEvaluationStep(evaluation: Evaluation, stepDefinition: EvaluationStepDefinition): EvaluationStep {
+  fun addStepToEvaluation(evaluation: Evaluation, stepDefinition: EvaluationStepDefinition): EvaluationStep {
     // remove existing step with this definition from evaluation
     evaluation.evaluationSteps.removeIf { it.definition == stepDefinition }
     return EvaluationStep(stepDefinition, evaluation, EvaluationStepStatus.PENDING).also {

--- a/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
@@ -11,7 +11,7 @@ import org.codefreak.codefreak.entity.Task
 import org.codefreak.codefreak.entity.User
 import org.codefreak.codefreak.repository.EvaluationStepDefinitionRepository
 import org.codefreak.codefreak.service.evaluation.EvaluationRunner
-import org.codefreak.codefreak.service.evaluation.EvaluationService
+import org.codefreak.codefreak.service.evaluation.EvaluationRunnerService
 import org.codefreak.codefreak.service.file.FileService
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -33,7 +33,7 @@ class TaskTarServiceTest {
   private lateinit var mockTaskService: TaskService
 
   @Mock
-  private lateinit var mockEvaluationService: EvaluationService
+  private lateinit var mockRunnerService: EvaluationRunnerService
 
   @Mock
   private lateinit var mockEvaluationStepDefinitionRepository: EvaluationStepDefinitionRepository
@@ -49,7 +49,7 @@ class TaskTarServiceTest {
     MockitoAnnotations.openMocks(this)
     `when`(mockTaskService.saveTask(any())).thenAnswer { it.arguments[0] }
 
-    `when`(mockEvaluationService.getEvaluationRunner(any())).thenAnswer {
+    `when`(mockRunnerService.getEvaluationRunner(any())).thenAnswer {
       object : EvaluationRunner {
         override fun getName(): String { return it.arguments[0] as String }
         override fun run(answer: Answer, options: Map<String, Any>) = listOf<Feedback>()


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
The comment handling was a bit broken since we create all evaluation steps before actually running them. Comments got lost when the automated evaluation is run. I used this to move some of the `EvaluationService` code to other classes.

Comments:
  * Create all evaluation steps if a comment is the first "executed" step
  * The default severity is `INFO` now
  * If the severity is not `INFO` the feedback is intepreted as `FAILED`
  * The severity select options are ordered by severity and not alphabetically
  * Set `finishedAt` field accordingly and trigger step finished event for each comment (this pushes comments in real-time to frontend)
  * The comment step stays in the "PENDING" status until the teacher adds the first comment. In the future we might add an option to manually set this status to indicate the teacher has finished his review without any comments (which is good). The previous logic was "everything is fine unless there is a comment" which is misleading.

Other
* There is now a standalone `EvaluationRunnerService`
* The state of an evaluation step is reset before re-evaluation

