### PR TITLE
Fix Evaluation stuck in a pending state

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
@@ -169,8 +169,7 @@ class EvaluationService : BaseService() {
         ?: throw RuntimeException("Evaluation does not contain a 'comments' step")
     evaluationStep.addFeedback(feedback)
 
-    // mark this evaluation step as "finished" which means "teacher evaluated this answer manually"
-    evaluationStep.status = EvaluationStepStatus.FINISHED
+    // Update the timestamp to indicate when the last comment was made
     evaluationStep.finishedAt = Instant.now()
     // if there is any failed feedback the overall step result is "failed"
     evaluationStep.result = when {

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepService.kt
@@ -69,7 +69,13 @@ class EvaluationStepService {
   fun addStepToEvaluation(evaluation: Evaluation, stepDefinition: EvaluationStepDefinition): EvaluationStep {
     // remove existing step with this definition from evaluation
     evaluation.evaluationSteps.removeIf { it.definition == stepDefinition }
-    return EvaluationStep(stepDefinition, evaluation, EvaluationStepStatus.PENDING).also {
+    // mark all manual steps as finished without a result
+    // otherwise the overall evaluation status would be stuck at "pending"
+    val initialStatus = when {
+      !runnerService.isAutomated(stepDefinition.runnerName) -> EvaluationStepStatus.FINISHED
+      else -> EvaluationStepStatus.PENDING
+    }
+    return EvaluationStep(stepDefinition, evaluation, initialStatus).also {
       evaluation.addStep(it)
     }
   }


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
With #898 I introduced a bug that evaluations are stuck in the "pending" status because the comments step is only marked as finished when a comment is added.
This PR reverts the old behavior and marks comment steps as "finished" when they are created.
