### PR TITLE
Fix queuedAt timestamp not persisted in DB

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationQueue.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationQueue.kt
@@ -1,6 +1,5 @@
 package org.codefreak.codefreak.service.evaluation
 
-import java.time.Instant
 import java.util.Date
 import org.codefreak.codefreak.config.EvaluationConfiguration
 import org.codefreak.codefreak.entity.Evaluation
@@ -57,7 +56,6 @@ class EvaluationQueue : StepExecutionListener {
     log.debug("Queuing evaluation step ${step.definition.runnerName} of answer ${step.evaluation.answer.id}")
     val params = buildJobParameters(step)
     jobLauncher.run(job, params)
-    step.queuedAt = Instant.now()
     // Warning: the step entity is detached because of Propagation.NOT_SUPPORTED (citation needed)
     // by passing only the id this will cause a re-fetch from the database
     evaluationStepService.updateEvaluationStepStatus(step.id, EvaluationStepStatus.QUEUED)
@@ -82,7 +80,6 @@ class EvaluationQueue : StepExecutionListener {
           evaluationStep.status >= EvaluationStepStatus.FINISHED -> evaluationStep.status
           else -> EvaluationStepStatus.FINISHED
         }
-        evaluationStep.finishedAt = Instant.now()
         evaluationStepService.updateEvaluationStepStatus(evaluationStep, status)
       }
     }

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationService.kt
@@ -18,7 +18,6 @@ import org.codefreak.codefreak.service.AssignmentStatusChangedEvent
 import org.codefreak.codefreak.service.BaseService
 import org.codefreak.codefreak.service.EntityNotFoundException
 import org.codefreak.codefreak.service.EvaluationStatusUpdatedEvent
-import org.codefreak.codefreak.service.EvaluationStepStatusUpdatedEvent
 import org.codefreak.codefreak.service.IdeService
 import org.codefreak.codefreak.service.SubmissionDeadlineReachedEvent
 import org.codefreak.codefreak.service.SubmissionService
@@ -169,8 +168,6 @@ class EvaluationService : BaseService() {
         ?: throw RuntimeException("Evaluation does not contain a 'comments' step")
     evaluationStep.addFeedback(feedback)
 
-    // Update the timestamp to indicate when the last comment was made
-    evaluationStep.finishedAt = Instant.now()
     // if there is any failed feedback the overall step result is "failed"
     evaluationStep.result = when {
       evaluationStep.feedback.any { it.isFailed } -> EvaluationStepResult.FAILED
@@ -180,7 +177,7 @@ class EvaluationService : BaseService() {
 
     // there is no real definition of "done" for comments, so we trigger a FINISHED event
     // each time a new comment is added to this answer
-    eventPublisher.publishEvent(EvaluationStepStatusUpdatedEvent(evaluationStep, EvaluationStepStatus.FINISHED))
+    stepService.updateEvaluationStepStatus(evaluationStep, EvaluationStepStatus.FINISHED)
     return feedback
   }
 

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepService.kt
@@ -1,5 +1,6 @@
 package org.codefreak.codefreak.service.evaluation
 
+import java.time.Instant
 import java.util.UUID
 import org.codefreak.codefreak.entity.Evaluation
 import org.codefreak.codefreak.entity.EvaluationStep
@@ -51,6 +52,13 @@ class EvaluationStepService {
 
   @Transactional
   fun updateEvaluationStepStatus(step: EvaluationStep, status: EvaluationStepStatus) {
+    // We do not check if the step is already in the given status on purpose.
+    // This allows updating the finishedAt timestamp (used for comments).
+    when (status) {
+      EvaluationStepStatus.QUEUED -> step.queuedAt = Instant.now()
+      EvaluationStepStatus.FINISHED -> step.finishedAt = Instant.now()
+      else -> Unit // all other status do not have a timestamp atm
+    }
     val evaluation = step.evaluation
     val originalEvaluationStatus = evaluation.stepStatusSummary
     step.status = status


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
`queuedAt` was not persisted in DB properly.
This fixes the issue and also centralizes the logic when the timestamps are set.