### PR TITLE
Don't show `Default configuration` if there is no configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The database of the development server is now seeded with the task templates and not from examples in the main repository ([#771](https://github.com/codefreak/codefreak/pull/771))
 * The timestamp of the last update is displayed in task pool and assignment list ([#552](https://github.com/codefreak/codefreak/pull/552))
 * The timestamp of the last update is shown in assignment details page ([#556](https://github.com/codefreak/codefreak/pull/556))
+* Don't show a "Default configuration" label on evaluation step configurations if there is no configuration ([#917](https://github.com/codefreak/codefreak/pull/917))

--- a/client/src/pages/evaluation/EditEvaluationPage.tsx
+++ b/client/src/pages/evaluation/EditEvaluationPage.tsx
@@ -276,13 +276,11 @@ const EditEvaluationPage: React.FC<{ taskId: string }> = ({ taskId }) => {
               </Descriptions.Item>
             ) : null}
           </Descriptions>
-          {definition.options === '{}' ? (
-            <i>Default configuration</i>
-          ) : (
+          {definition.options !== '{}' ? (
             <SyntaxHighlighter language="yaml" noLineNumbers>
               {YAML.stringify(JSON.parse(definition.options))}
             </SyntaxHighlighter>
-          )}
+          ) : null}
         </>
       )
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
The comment and command-line evaluation steps have no configuration but still show a "Default configuration" label. This label should be removed when there are no configuration options.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
