### PR TITLE
Fix TransactionManager not injected properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The database of the development server is now seeded with the task templates and not from examples in the main repository ([#771](https://github.com/codefreak/codefreak/pull/771))
 * The timestamp of the last update is displayed in task pool and assignment list ([#552](https://github.com/codefreak/codefreak/pull/552))
 * The timestamp of the last update is shown in assignment details page ([#556](https://github.com/codefreak/codefreak/pull/556))
+* Don't show a "Default configuration" label on evaluation step configurations if there is no configuration ([#917](https://github.com/codefreak/codefreak/pull/917))

--- a/client/src/pages/evaluation/EditEvaluationPage.tsx
+++ b/client/src/pages/evaluation/EditEvaluationPage.tsx
@@ -276,13 +276,11 @@ const EditEvaluationPage: React.FC<{ taskId: string }> = ({ taskId }) => {
               </Descriptions.Item>
             ) : null}
           </Descriptions>
-          {definition.options === '{}' ? (
-            <i>Default configuration</i>
-          ) : (
+          {definition.options !== '{}' ? (
             <SyntaxHighlighter language="yaml" noLineNumbers>
               {YAML.stringify(JSON.parse(definition.options))}
             </SyntaxHighlighter>
-          )}
+          ) : null}
         </>
       )
     }

--- a/src/main/kotlin/org/codefreak/codefreak/service/BaseService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/BaseService.kt
@@ -13,7 +13,7 @@ abstract class BaseService {
   protected lateinit var entityManager: EntityManager
 
   @Autowired
-  private lateinit var transactionManager: PlatformTransactionManager
+  protected open lateinit var transactionManager: PlatformTransactionManager
 
   protected fun <T> withNewTransaction(block: TransactionCallback<T>): T {
     val transactionTemplate = TransactionTemplate(transactionManager)


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
Not sure why... but to make `@Autowired` work on abstract classes the prop has to be `open` and thus also `protected`.