### PR TITLE
Fix TransactionManager not injected properly

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/service/BaseService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/BaseService.kt
@@ -13,7 +13,7 @@ abstract class BaseService {
   protected lateinit var entityManager: EntityManager
 
   @Autowired
-  private lateinit var transactionManager: PlatformTransactionManager
+  protected open lateinit var transactionManager: PlatformTransactionManager
 
   protected fun <T> withNewTransaction(block: TransactionCallback<T>): T {
     val transactionTemplate = TransactionTemplate(transactionManager)


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
Not sure why... but to make `@Autowired` work on abstract classes the prop has to be `open` and thus also `protected`.