### PR TITLE
Allow teachers to access others assignments

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/graphql/api/AssignmentApi.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/graphql/api/AssignmentApi.kt
@@ -108,7 +108,7 @@ class AssignmentQuery : BaseResolver(), Query {
   fun assignment(id: UUID): AssignmentDto = context {
     val assignment = serviceAccess.getService(AssignmentService::class).findAssignment(id)
     if (assignment.status == AssignmentStatus.INACTIVE) {
-      authorization.requireAuthorityIfNotCurrentUser(assignment.owner, Authority.ROLE_ADMIN)
+      authorization.requireAuthorityIfNotCurrentUser(assignment.owner, Authority.ROLE_TEACHER)
     }
     AssignmentDto(assignment, this)
   }


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
As long as we do not have a proper classroom/sharing option, teachers should be able to read other teachers assignments regardless of the status