### PR TITLE
Improve file API

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/graphql/api/FileApi.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/graphql/api/FileApi.kt
@@ -117,21 +117,26 @@ class FileMutation : BaseResolver(), Mutation {
     true
   }
 
-  fun uploadFile(fileContext: FileContext, path: String, contents: ApplicationPart): Boolean = context {
+  fun uploadFiles(fileContext: FileContext, dir: String, files: Array<ApplicationPart>): Boolean = context {
     authorize(fileContext)
-    serviceAccess.getService(FileService::class).writeFile(fileContext.id, path).use {
-      IOUtils.copy(contents.inputStream, it)
+    val fileService = serviceAccess.getService(FileService::class)
+    files.forEach { file ->
+      val filename = file.submittedFileName ?: "upload-${Instant.now()}-${file.name}"
+      val filePath = "$dir/$filename"
+      fileService.writeFile(fileContext.id, filePath).use {
+        IOUtils.copy(file.inputStream, it)
+      }
     }
     true
   }
 
-  fun moveFile(fileContext: FileContext, sources: List<String>, target: String): Boolean = context {
+  fun moveFiles(fileContext: FileContext, sources: List<String>, target: String): Boolean = context {
     authorize(fileContext)
     serviceAccess.getService(FileService::class).moveFile(fileContext.id, sources.toSet(), target)
     true
   }
 
-  fun deleteFile(fileContext: FileContext, paths: List<String>): Boolean = context {
+  fun deleteFiles(fileContext: FileContext, paths: List<String>): Boolean = context {
     authorize(fileContext)
     serviceAccess.getService(FileService::class).deleteFiles(fileContext.id, paths.toSet())
     true

--- a/src/main/kotlin/org/codefreak/codefreak/service/TaskTarService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/TaskTarService.kt
@@ -132,7 +132,10 @@ class TaskTarService : BaseService() {
 
   private fun copyTaskFilesFromTar(taskId: UUID, tarContent: ByteArray) {
     fileService.writeCollectionTar(taskId).use { fileCollection ->
-      TarUtil.copyEntries(tarContent.inputStream(), fileCollection, filter = { !TarUtil.isCodefreakDefinition(it) })
+      TarUtil.copyEntries(
+          TarArchiveInputStream(tarContent.inputStream()),
+          TarUtil.PosixTarArchiveOutputStream(fileCollection)
+      ) { !TarUtil.isCodefreakDefinition(it) }
     }
   }
 

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/FileContentService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/FileContentService.kt
@@ -23,11 +23,13 @@ class FileContentService : BaseService() {
     SYMLINK
   }
 
-  class VirtualFile(
+  data class VirtualFile(
     val path: String,
     val lastModifiedDate: Instant,
     val type: VirtualFileType,
-    val content: ByteArray?
+    val content: ByteArray?,
+    val size: Long,
+    val mode: Int
   )
 
   fun getFile(fileCollectionId: UUID, path: String): VirtualFile {
@@ -61,7 +63,9 @@ class FileContentService : BaseService() {
           entry.isLink || entry.isSymbolicLink -> VirtualFileType.SYMLINK
           entry.isDirectory -> VirtualFileType.DIRECTORY
           else -> VirtualFileType.FILE
-        }
+        },
+        size = entry.size,
+        mode = entry.mode
     )
   }
 }

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/FileMetaData.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/FileMetaData.kt
@@ -1,0 +1,45 @@
+package org.codefreak.codefreak.service.file
+
+import java.time.Instant
+
+/**
+ * Possible type of files in a collection.
+ * There is no support for symlinks as they will be pretty hard to tame.
+ */
+enum class FileType {
+  FILE,
+  DIRECTORY
+}
+
+/**
+ * Contains the meta information about a file in a collection.
+ */
+data class FileMetaData(
+  /**
+   * Indicates the type of the file.
+   * @see FileType
+   */
+  val type: FileType,
+
+  /**
+   * Absolute path of the file in the collection.
+   * Always starts with a leading slash and never has a trailing slash.
+   */
+  val path: String,
+
+  /**
+   * Timestamp when the file has last been modified.
+   */
+  val lastModifiedDate: Instant,
+
+  /**
+   * Permissions of this file represented as UNIX mode
+   */
+  val mode: Int,
+
+  /**
+   * Size of the file.
+   * Will be null for non-files
+   */
+  val size: Long?
+)

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
@@ -39,6 +39,7 @@ interface FileService {
   /**
    * Create empty files in places specified by path.
    * Throws an IllegalArgumentException if the parent directory does not exist or existing path is a directory.
+   * Ignores silently if a file already exists (similar to Linux' "touch")
    */
   @Throws(IllegalArgumentException::class)
   fun createFiles(collectionId: UUID, paths: Set<String>)
@@ -46,7 +47,7 @@ interface FileService {
   /**
    * Create directories places specified by path.
    * This will create all parent directories in case they do not exist.
-   * Ignores silently if a directory already exists.
+   * Ignores silently if a directory already exists (similar to Linux' "mkdir -p")
    */
   fun createDirectories(collectionId: UUID, paths: Set<String>)
 

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
@@ -82,6 +82,7 @@ interface FileService {
    *   - Target must not be one of the descendants of source (moving something to itself)
    *   - Basename of each source must not be existent in target
    *   - Moving directories preserves the directory structure
+   *   - Ignore silently if a file is moved to itself (e.g. /some/file.txt is moved to /some/)
    *
    * If one of the conditions above does not match an IllegalArgumentException is thrown.
    */

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
@@ -45,7 +45,7 @@ interface FileService {
 
   /**
    * Create directories places specified by path.
-   * This will create all parent directories in case the do not exist.
+   * This will create all parent directories in case they do not exist.
    * Ignores silently if a directory already exists.
    */
   fun createDirectories(collectionId: UUID, paths: Set<String>)

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
@@ -3,6 +3,7 @@ package org.codefreak.codefreak.service.file
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.UUID
+import kotlin.jvm.Throws
 import org.springframework.util.DigestUtils
 import org.springframework.util.StreamUtils
 
@@ -22,13 +23,83 @@ interface FileService {
     return readCollectionTar(collectionId).use { DigestUtils.md5Digest(it) }
   }
 
-  fun listFiles(collectionId: UUID): List<String>
-  fun createFile(collectionId: UUID, path: String)
-  fun createDirectory(collectionId: UUID, path: String)
+  /**
+   * Walk over every file or directory in the given collection.
+   * Returns a sequence with ALL files from this collection.
+   */
+  fun walkFileTree(collectionId: UUID): Sequence<FileMetaData>
+
+  /**
+   * List all files and directories that are direct descendants of path
+   * Throws an IllegalArgumentException if path does not exist
+   */
+  @Throws(IllegalArgumentException::class)
+  fun listFiles(collectionId: UUID, path: String): Sequence<FileMetaData>
+
+  /**
+   * Create empty files in places specified by path.
+   * Throws an IllegalArgumentException if the parent directory does not exist or existing path is a directory.
+   */
+  @Throws(IllegalArgumentException::class)
+  fun createFiles(collectionId: UUID, paths: Set<String>)
+
+  /**
+   * Create directories places specified by path.
+   * This will create all parent directories in case the do not exist.
+   * Ignores silently if a directory already exists.
+   */
+  fun createDirectories(collectionId: UUID, paths: Set<String>)
+
+  /**
+   * Denotes if path exists and is a file
+   */
   fun containsFile(collectionId: UUID, path: String): Boolean
+
+  /**
+   * Denotes if path exists and is a directory
+   */
   fun containsDirectory(collectionId: UUID, path: String): Boolean
-  fun deleteFile(collectionId: UUID, path: String)
-  fun filePutContents(collectionId: UUID, path: String): OutputStream
-  fun getFileContents(collectionId: UUID, path: String): InputStream
-  fun moveFile(collectionId: UUID, from: String, to: String)
+
+  /**
+   * Delete files specified by path.
+   * Directories are always deleted recursively!
+   * Throws an exception if one of the paths did not exist.
+   */
+  @Throws(IllegalArgumentException::class)
+  fun deleteFiles(collectionId: UUID, paths: Set<String>)
+
+  /**
+   * Move one or multiple source files to target.
+   * The behaviour depends on the type of target.
+   * - Always:
+   *   - All sources must be existing files or directories
+   * - If target does not exist (renaming a single file/directory):
+   *   - Only a single source is allowed
+   * - If target does exist (moving multiple files/dir to a folder):
+   *   - Target must be an existing directory
+   *   - One or multiple files are allowed
+   *   - Target must not be one of the descendants of source (moving something to itself)
+   *   - Basename of each source must not be existent in target
+   *   - Moving directories preserves the directory structure
+   *
+   * If one of the conditions above does not match an IllegalArgumentException is thrown.
+   */
+  @Throws(IllegalArgumentException::class)
+  fun moveFile(collectionId: UUID, sources: Set<String>, target: String)
+
+  /**
+   * Write to file specified by path. Will create the file if it does not exist and truncate existing content.
+   * The output stream must be closed properly after writing!
+   * Throws an IllegalArgumentException if path does not exist or is a directory.
+   */
+  @Throws(IllegalArgumentException::class)
+  fun writeFile(collectionId: UUID, path: String): OutputStream
+
+  /**
+   * Read content from file.
+   * The output stream must be closed properly after reading!
+   * Throws an IllegalArgumentException if path does not exist or is a directory.
+   */
+  @Throws(IllegalArgumentException::class)
+  fun readFile(collectionId: UUID, path: String): InputStream
 }

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
@@ -90,7 +90,7 @@ interface FileService {
   /**
    * Write to file specified by path. Will create the file if it does not exist and truncate existing content.
    * The output stream must be closed properly after writing!
-   * Throws an IllegalArgumentException if path does not exist or is a directory.
+   * Throws an IllegalArgumentException if path is a directory.
    */
   @Throws(IllegalArgumentException::class)
   fun writeFile(collectionId: UUID, path: String): OutputStream

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
@@ -304,6 +304,10 @@ class JpaFileService : FileService {
         )
       }
     } else {
+      if (sources.size == 1 && TarUtil.normalizeFileName(target) == TarUtil.normalizeFileName(sources.first())) {
+        // Renaming a single item to itself. Our job is done here.
+        return
+      }
       // move things to a directory
       if (!targetEntry.isDirectory) {
         throw IllegalArgumentException("Cannot move to $target: Is not directory")
@@ -330,7 +334,7 @@ class JpaFileService : FileService {
 
       // make sure we will not override something in the new directory
       replaceMap.forEach { (oldName, newName) ->
-        require(!containsPath(collectionId, newName)) {
+        require(oldName == newName || !containsPath(collectionId, newName)) {
           "Cannot move ${oldName.withoutTrailingSlash()} to $target: ${newName.withoutTrailingSlash()} already exists"
         }
       }

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
@@ -1,12 +1,5 @@
 package org.codefreak.codefreak.service.file
 
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
-import java.io.OutputStream
-import java.nio.file.Path
-import java.nio.file.Paths
-import java.util.UUID
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.archivers.tar.TarConstants
@@ -21,6 +14,13 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 import org.springframework.util.DigestUtils
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.UUID
 
 @Service
 @ConditionalOnProperty(name = ["codefreak.files.adapter"], havingValue = "JPA")
@@ -322,12 +322,12 @@ class JpaFileService : FileService {
           }
 
           listOf(
-              Pair(normalizedSource, targetPrefix + sourceBasename + "/"),
-              Pair(normalizedSource.withoutTrailingSlash(), targetPrefix + sourceBasename)
+              Pair(normalizedSource, TarUtil.normalizeDirectoryName(targetPrefix + sourceBasename)),
+              Pair(normalizedSource.withoutTrailingSlash(), TarUtil.normalizeFileName(targetPrefix + sourceBasename))
           )
         } else {
           listOf(
-              Pair(normalizedSource, targetPrefix + sourceBasename)
+              Pair(normalizedSource, TarUtil.normalizeFileName(targetPrefix + sourceBasename))
           )
         }
       }.toMap()

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
@@ -133,6 +133,10 @@ class JpaFileService : FileService {
     path: String,
     restriction: (TarArchiveEntry) -> Boolean = { true }
   ): TarArchiveEntry? {
+    // create a fake root entry as it might not be present in some archives
+    if (TarUtil.isRoot(path)) {
+      return TarArchiveEntry("./")
+    }
     val normalizedFileName = TarUtil.normalizeFileName(path)
     getTarInputStream(collectionId).use { archive ->
       return archive.entrySequence().firstOrNull {

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
@@ -175,6 +175,9 @@ class JpaFileService : FileService {
         requireValidPath(it)
         require(!containsFile(collectionId, it))
       }
+    }.filter {
+      // only create directories that are not already existing
+      !containsDirectory(collectionId, it)
     }
 
     getTarOutputStream(collectionId).use { output ->

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
@@ -1,5 +1,12 @@
 package org.codefreak.codefreak.service.file
 
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.UUID
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.archivers.tar.TarConstants
@@ -14,13 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 import org.springframework.util.DigestUtils
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
-import java.io.OutputStream
-import java.nio.file.Path
-import java.nio.file.Paths
-import java.util.UUID
 
 @Service
 @ConditionalOnProperty(name = ["codefreak.files.adapter"], havingValue = "JPA")

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/JpaFileService.kt
@@ -4,16 +4,17 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
+import java.nio.file.Paths
 import java.util.UUID
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
 import org.apache.commons.compress.utils.IOUtils
 import org.codefreak.codefreak.entity.FileCollection
 import org.codefreak.codefreak.repository.FileCollectionRepository
 import org.codefreak.codefreak.service.EntityNotFoundException
 import org.codefreak.codefreak.util.TarUtil
 import org.codefreak.codefreak.util.TarUtil.entrySequence
+import org.codefreak.codefreak.util.withoutTrailingSlash
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
@@ -55,52 +56,65 @@ class JpaFileService : FileService {
     return DigestUtils.md5Digest(getCollection(collectionId).tar)
   }
 
-  override fun listFiles(collectionId: UUID): List<String> {
-    getTarInputStream(collectionId).use {
-      return it.entrySequence().map { entry ->
-        if (entry.isDirectory) {
-          TarUtil.normalizeDirectoryName(entry.name)
-        } else {
-          TarUtil.normalizeFileName(entry.name)
-        }
-      }.toList()
+  override fun walkFileTree(collectionId: UUID): Sequence<FileMetaData> {
+    getTarInputStream(collectionId).use { stream ->
+      return stream.entrySequence()
+          .map { tarEntryToFileMetaData(it) }
     }
   }
 
-  override fun createFile(collectionId: UUID, path: String) {
-    val normalizedPath = TarUtil.normalizeFileName(path)
+  override fun listFiles(collectionId: UUID, path: String): Sequence<FileMetaData> {
+    val parentPath = Paths.get("/" + TarUtil.normalizeFileName(path))
+    return walkFileTree(collectionId).filter {
+      Paths.get(it.path).parent == parentPath
+    }
+  }
 
-    requireValidPath(normalizedPath)
-    requireFileDoesNotExist(collectionId, normalizedPath)
+  private fun tarEntryToFileMetaData(entry: TarArchiveEntry): FileMetaData {
+    return FileMetaData(
+        path = "/" + TarUtil.normalizeFileName(entry.name),
+        lastModifiedDate = entry.modTime.toInstant(),
+        type = when {
+          entry.isDirectory -> FileType.DIRECTORY
+          else -> FileType.FILE
+        },
+        size = entry.size,
+        mode = entry.mode
+    )
+  }
 
-    getTarOutputStream(collectionId).use {
-      val input = getTarInputStream(collectionId)
-      TarUtil.copyEntries(input, it)
-      TarUtil.touch(normalizedPath, it)
+  override fun createFiles(collectionId: UUID, paths: Set<String>) {
+    val normalizedPaths = paths.map { path ->
+      TarUtil.normalizeFileName(path).also {
+        requireValidPath(it)
+        require(!containsPath(collectionId, it))
+      }
+    }
+
+    getTarOutputStream(collectionId).use { output ->
+      getTarInputStream(collectionId).use { input ->
+        TarUtil.copyEntries(input, output)
+      }
+      normalizedPaths.forEach { TarUtil.touch(it, output) }
     }
   }
 
   private fun requireValidPath(path: String) = require(path.isNotBlank()) { "`$path` is not a valid path" }
   private fun requireFileDoesExist(collectionId: UUID, path: String) =
-    require(containsFile(collectionId, path)) { "File `$path` does not exist" }
+      require(containsFile(collectionId, path)) { "File `$path` does not exist" }
 
   private fun requireFileDoesNotExist(collectionId: UUID, path: String) =
-    require(!containsFile(collectionId, path)) { "File `$path` already exists" }
-
-  private fun requireDirectoryDoesExist(collectionId: UUID, path: String) =
-    require(containsDirectory(collectionId, path)) { "Directory `$path` does not exist" }
+      require(!containsFile(collectionId, path)) { "File `$path` already exists" }
 
   private fun requireDirectoryDoesNotExist(collectionId: UUID, path: String) =
-    require(!containsDirectory(collectionId, path)) { "Directory `$path` already exists" }
+      require(!containsDirectory(collectionId, path)) { "Directory `$path` already exists" }
 
   override fun containsFile(collectionId: UUID, path: String): Boolean {
-    val normalizedPath = TarUtil.normalizeFileName(path)
-    return containsPath(collectionId, normalizedPath) { it.isFile }
+    return containsPath(collectionId, path) { it.isFile }
   }
 
   override fun containsDirectory(collectionId: UUID, path: String): Boolean {
-    val normalizedPath = TarUtil.normalizeDirectoryName(path)
-    return containsPath(collectionId, normalizedPath) { it.isDirectory }
+    return containsPath(collectionId, path) { it.isDirectory }
   }
 
   private fun containsPath(
@@ -114,43 +128,52 @@ class JpaFileService : FileService {
     path: String,
     restriction: (TarArchiveEntry) -> Boolean = { true }
   ): TarArchiveEntry? {
+    val normalizedFileName = TarUtil.normalizeFileName(path)
     getTarInputStream(collectionId).use { archive ->
-      return archive.entrySequence().firstOrNull { it.name == path && restriction(it) }
+      return archive.entrySequence().firstOrNull {
+        TarUtil.normalizeFileName(it.name) == normalizedFileName && restriction(it)
+      }
     }
   }
 
   private fun getTarInputStream(collectionId: UUID) = TarArchiveInputStream(readCollectionTar(collectionId))
 
-  private fun getTarOutputStream(collectionId: UUID) = TarArchiveOutputStream(writeCollectionTar(collectionId))
+  private fun getTarOutputStream(collectionId: UUID) = TarUtil.PosixTarArchiveOutputStream(writeCollectionTar(collectionId))
 
-  override fun createDirectory(collectionId: UUID, path: String) {
-    val normalizedPath = TarUtil.normalizeDirectoryName(path)
+  override fun createDirectories(collectionId: UUID, paths: Set<String>) {
+    val normalizedPaths = paths.map { path ->
+      TarUtil.normalizeFileName(path).also {
+        requireValidPath(it)
+        require(!containsPath(collectionId, it))
+      }
+    }
 
-    requireValidPath(normalizedPath)
-    requireDirectoryDoesNotExist(collectionId, normalizedPath)
-
-    getTarOutputStream(collectionId).use {
-      val input = getTarInputStream(collectionId)
-      TarUtil.copyEntries(input, it)
-      TarUtil.mkdir(normalizedPath, it)
+    getTarOutputStream(collectionId).use { output ->
+      getTarInputStream(collectionId).use { input ->
+        TarUtil.copyEntries(input, output)
+      }
+      normalizedPaths.forEach { TarUtil.mkdir(it, output) }
     }
   }
 
-  override fun deleteFile(collectionId: UUID, path: String) {
-    requireValidPath(TarUtil.normalizeEntryName(path))
-    val fileExists = containsFile(collectionId, TarUtil.normalizeFileName(path))
-    val directoryExists = containsDirectory(collectionId, TarUtil.normalizeDirectoryName(path))
-    require(fileExists.or(directoryExists)) { "`$path` does not exist" }
+  override fun deleteFiles(collectionId: UUID, paths: Set<String>) {
+    val normalizedPaths = paths.map { path ->
+      requireValidPath(TarUtil.normalizeEntryName(path))
+      val fileExists = containsFile(collectionId, TarUtil.normalizeFileName(path))
+      val directoryExists = containsDirectory(collectionId, TarUtil.normalizeDirectoryName(path))
+      require(fileExists || directoryExists) { "`$path` does not exist" }
 
-    val normalizedPath = if (fileExists) TarUtil.normalizeFileName(path) else TarUtil.normalizeDirectoryName(path)
+      if (fileExists) TarUtil.normalizeFileName(path) else TarUtil.normalizeDirectoryName(path)
+    }
 
-    getTarOutputStream(collectionId).use {
-      val input = getTarInputStream(collectionId)
-      TarUtil.copyEntries(input, it, { entry -> !entry.name.startsWith(normalizedPath) })
+    getTarOutputStream(collectionId).use { output ->
+      getTarInputStream(collectionId).use { input ->
+        TarUtil.copyEntries(input, output) { entry -> !normalizedPaths.any { entry.name.startsWith(it) } }
+      }
     }
   }
 
-  override fun filePutContents(collectionId: UUID, path: String): OutputStream {
+  override fun writeFile(collectionId: UUID, path: String): OutputStream {
     val normalizedPath = TarUtil.normalizeFileName(path)
 
     requireValidPath(normalizedPath)
@@ -162,19 +185,20 @@ class JpaFileService : FileService {
         val entryToPut = findEntry(collectionId, normalizedPath)!!
         entryToPut.size = contents.size.toLong()
 
-        getTarOutputStream(collectionId).use {
-          val tar = getTarInputStream(collectionId)
-          TarUtil.copyEntries(tar, it, { entry -> entry.name != normalizedPath })
+        getTarOutputStream(collectionId).use { output ->
+          getTarInputStream(collectionId).use { input ->
+            TarUtil.copyEntries(input, output) { entry -> entry.name != normalizedPath }
+          }
 
-          it.putArchiveEntry(entryToPut)
-          IOUtils.copy(contents.inputStream(), it)
-          it.closeArchiveEntry()
+          output.putArchiveEntry(entryToPut)
+          IOUtils.copy(contents.inputStream(), output)
+          output.closeArchiveEntry()
         }
       }
     }
   }
 
-  override fun getFileContents(collectionId: UUID, path: String): InputStream {
+  override fun readFile(collectionId: UUID, path: String): InputStream {
     val normalizedPath = TarUtil.normalizeFileName(path)
 
     requireValidPath(normalizedPath)
@@ -193,35 +217,100 @@ class JpaFileService : FileService {
     return ByteArrayInputStream(byteArrayOf())
   }
 
-  override fun moveFile(collectionId: UUID, from: String, to: String) {
-    var normalizedFrom = TarUtil.normalizeEntryName(from)
-    var normalizedTo = TarUtil.normalizeEntryName(to)
-
-    requireValidPath(normalizedFrom)
-    requireValidPath(normalizedTo)
-
-    val isDirectory = containsDirectory(collectionId, TarUtil.normalizeDirectoryName(from))
-    if (isDirectory) {
-      normalizedFrom = TarUtil.normalizeDirectoryName(from)
-      normalizedTo = TarUtil.normalizeDirectoryName(to)
-
-      requireDirectoryDoesExist(collectionId, normalizedFrom)
-      requireDirectoryDoesNotExist(collectionId, normalizedTo)
-    } else {
-      requireFileDoesExist(collectionId, normalizedFrom)
-      requireFileDoesNotExist(collectionId, normalizedTo)
+  override fun moveFile(collectionId: UUID, sources: Set<String>, target: String) {
+    if (sources.isEmpty()) {
+      throw IllegalArgumentException("At least a single source has to be given")
     }
 
-    moveFileOrDirectory(collectionId, normalizedFrom, normalizedTo)
-  }
+    // first make sure all source files exist and get their canonical path
+    val normalizedSources = sources.map { source ->
+      val normalizedPath = TarUtil.normalizeFileName(source)
+      requireValidPath(normalizedPath)
+      // get information about the file
+      val entry = findEntry(collectionId, normalizedPath)
+      when {
+        entry == null -> throw IllegalArgumentException("$source does not exist in $collectionId")
+        entry.isDirectory -> TarUtil.normalizeDirectoryName(source)
+        else -> TarUtil.normalizeFileName(source)
+      }
+    }
 
-  private fun moveFileOrDirectory(collectionId: UUID, from: String, to: String) {
+    // The following part will create a "replace map" for each source and target depending on the target type.
+    // The map is a search->replace string pair where each path starting with search will be replaced.
+    // Three cases must be handled:
+    // 1. rename a file (1:1 rename of /foo/bar to /foo/baz)
+    // -> sources.size == 1 && target does not exist && source is file
+    // 2. rename a dir (everything prefixed with /foo/bar/* and /foo/bar itself to /foo/baz)
+    // -> sources.size == 1 && target does not exist && source is dir
+    // 3. move multiple items to dir (prefix every basename (!) of source with target)
+    // -> target exists && target is dir
+
+    val targetEntry = findEntry(collectionId, target)
+    val replaceMap: Map<String, String>
+    if (targetEntry == null) {
+      // renaming dir or file
+      if (sources.size > 1) {
+        throw IllegalArgumentException("$target is not a directory")
+      }
+      val renameSource = normalizedSources.first()
+      replaceMap = if (renameSource.endsWith("/")) {
+        // renaming a directory
+        // we have to rename everything with prefix /foo/bar/* and /foo/bar itself
+        mapOf(
+            renameSource to TarUtil.normalizeDirectoryName(target),
+            renameSource.withoutTrailingSlash() to TarUtil.normalizeFileName(target)
+        )
+      } else {
+        // renaming a file
+        // simple 1:1 mapping of /foo/bar to /foo/baz
+        mapOf(
+            renameSource to TarUtil.normalizeFileName(target)
+        )
+      }
+    } else {
+      // move things to a directory
+      if (!targetEntry.isDirectory) {
+        throw IllegalArgumentException("Cannot move to $target: Is not directory")
+      }
+      // prefix is now something like /hello/world/
+      val targetPrefix = TarUtil.normalizeDirectoryName(target)
+      replaceMap = normalizedSources.flatMap { normalizedSource ->
+        val sourceBasename = Paths.get("/$normalizedSource").fileName.toString()
+        if (normalizedSource.endsWith("/")) {
+          if (targetPrefix.startsWith(normalizedSource)) {
+            throw IllegalArgumentException("Cannot move '$normalizedSource' to a subdirectory of itself '$targetPrefix'")
+          }
+
+          listOf(
+              Pair(normalizedSource, targetPrefix + sourceBasename + "/"),
+              Pair(normalizedSource.withoutTrailingSlash(), targetPrefix + sourceBasename)
+          )
+        } else {
+          listOf(
+              Pair(normalizedSource, targetPrefix + sourceBasename)
+          )
+        }
+      }.toMap()
+
+      // make sure we will not override something in the new directory
+      replaceMap.forEach { (oldName, newName) ->
+        require(!containsPath(collectionId, newName)) {
+          "Cannot move ${oldName.withoutTrailingSlash()} to $target: ${newName.withoutTrailingSlash()} already exists"
+        }
+      }
+    }
+
+    // go over every entry and replace all paths based on our map
     getTarOutputStream(collectionId).use { tar ->
       getTarInputStream(collectionId).use { input ->
         input.entrySequence().forEach { entry ->
-          if (entry.name.startsWith(from)) {
-            entry.name = entry.name.replace(from, to)
-          }
+          // find first matching replacement pattern and apply it to the name
+          // otherwise leave the entry name untouched
+          entry.name = replaceMap.entries.find { (search, _) ->
+            TarUtil.normalizeFileName(entry.name).startsWith(search)
+          }?.let { (search, replace) ->
+            TarUtil.normalizeFileName(entry.name).replaceRange(0, search.length, replace)
+          } ?: entry.name
 
           tar.putArchiveEntry(entry)
           IOUtils.copy(input, tar)

--- a/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
@@ -90,7 +90,7 @@ object TarUtil {
     return out.toByteArray()
   }
 
-  private fun isRoot(path: String) = normalizeEntryName(path).isBlank()
+  fun isRoot(path: String) = normalizeEntryName(path).isBlank()
   fun isRoot(entry: TarArchiveEntry) = isRoot(entry.name)
 
   private fun createTarRootDirectory(outputStream: TarArchiveOutputStream) {

--- a/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
@@ -144,17 +144,16 @@ object TarUtil {
   fun normalizeEntryName(name: String) = name.trim().replace(stripPrefixPattern, "").trim()
 
   fun copyEntries(
-    from: InputStream,
-    to: OutputStream,
-    filter: (TarArchiveEntry) -> Boolean = { true },
-    prefix: String? = null
-  ) = copyEntries(TarArchiveInputStream(from), PosixTarArchiveOutputStream(to), filter, prefix)
+    from: TarArchiveInputStream,
+    to: TarArchiveOutputStream,
+    filter: (TarArchiveEntry) -> Boolean = { true }
+  ) = copyEntries(from, to, filter, null)
 
   fun copyEntries(
     from: TarArchiveInputStream,
     to: TarArchiveOutputStream,
     filter: (TarArchiveEntry) -> Boolean = { true },
-    prefix: String? = null
+    prefix: String?
   ) {
     generateSequence { from.nextTarEntry }
         .filter(filter)

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -38,6 +38,14 @@ class JpaFileServiceTest {
     assertTrue(fileService.containsFile(collectionId, "file.txt"))
   }
 
+  @Test
+  fun `creates multiple files`() {
+    fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt", "file3.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file1.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file2.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file3.txt"))
+  }
+
   @Test(expected = IllegalArgumentException::class)
   fun `creating a file throws when the path already exists`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
@@ -45,8 +53,24 @@ class JpaFileServiceTest {
   }
 
   @Test(expected = IllegalArgumentException::class)
+  fun `creating a file two times at once throws`() {
+    fileService.createFiles(collectionId, setOf("file.txt", "file.txt"))
+  }
+
+  @Test(expected = IllegalArgumentException::class)
   fun `creating a file throws on empty path name`() {
     fileService.createFiles(collectionId, setOf(""))
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `creating a file throws when path is a directory`() {
+    fileService.createDirectories(collectionId, setOf("some/path"))
+    fileService.createFiles(collectionId, setOf("some/path"))
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `creating a file throws when the parent directory does not exist`() {
+    fileService.createFiles(collectionId, setOf("parent/file.txt"))
   }
 
   @Test
@@ -56,6 +80,18 @@ class JpaFileServiceTest {
     fileService.createFiles(collectionId, setOf("file.txt"))
 
     assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "other.txt"))
+    assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
+  }
+
+  @Test
+  fun `creating multiple files keeps other files intact`() {
+    fileService.createFiles(collectionId, setOf("other.txt"))
+    fileService.createDirectories(collectionId, setOf("aDirectory"))
+    fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt"))
+
+    assertTrue(fileService.containsFile(collectionId, "file1.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file2.txt"))
     assertTrue(fileService.containsFile(collectionId, "other.txt"))
     assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
   }

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -9,6 +9,7 @@ import org.codefreak.codefreak.service.file.FileService
 import org.codefreak.codefreak.service.file.JpaFileService
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.mockito.InjectMocks
@@ -187,9 +188,31 @@ class JpaFileServiceTest {
     assertFalse(fileService.containsFile(collectionId, "file.txt"))
   }
 
+  @Test
+  fun `deletes multiple existing files`() {
+    fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt"))
+
+    fileService.deleteFiles(collectionId, setOf("file1.txt", "file2.txt"))
+
+    assertFalse(fileService.containsFile(collectionId, "file1.txt"))
+    assertFalse(fileService.containsFile(collectionId, "file2.txt"))
+  }
+
   @Test(expected = IllegalArgumentException::class)
   fun `deleting a file throws when path does not exist`() {
     fileService.deleteFiles(collectionId, setOf("file.txt"))
+  }
+
+  @Test
+  fun `deleting multiple files does not delete any file when one of the files does not exist`() {
+    fileService.createFiles(collectionId, setOf("file1.txt"))
+
+    try {
+      fileService.deleteFiles(collectionId, setOf("file1.txt", "file2.txt"))
+      fail() // An IllegalArgumentException should be thrown
+    } catch (e: IllegalArgumentException) {}
+
+    assertTrue(fileService.containsFile(collectionId, "file1.txt"))
   }
 
   @Test
@@ -212,6 +235,28 @@ class JpaFileServiceTest {
     fileService.deleteFiles(collectionId, setOf("some/path"))
 
     assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+  }
+
+  @Test
+  fun `deletes multiple existing directories`() {
+    fileService.createDirectories(collectionId, setOf("some/path", "some/other/path"))
+
+    fileService.deleteFiles(collectionId, setOf("some/path", "some/other/path"))
+
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/other/path"))
+  }
+
+  @Test
+  fun `deletes existing files and directories`() {
+    fileService.createDirectories(collectionId, setOf("some/path", "some/other/path", "file1.txt", "file2.txt"))
+
+    fileService.deleteFiles(collectionId, setOf("some/path", "some/other/path", "file1.txt", "file2.txt"))
+
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/other/path"))
+    assertFalse(fileService.containsFile(collectionId, "file1.txt"))
+    assertFalse(fileService.containsFile(collectionId, "file2.txt"))
   }
 
   @Test

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -608,4 +608,20 @@ class JpaFileServiceTest {
     fileService.moveFile(collectionId, setOf("some/path"), "/")
     assertTrue(fileService.containsDirectory(collectionId, "path"))
   }
+
+  @Test
+  fun `ignore if renaming file to itself`() {
+    fileService.createDirectories(collectionId, setOf("some"))
+    fileService.createFiles(collectionId, setOf("some/file.txt"))
+    fileService.moveFile(collectionId, setOf("some/file.txt"), "some/file.txt")
+    assertTrue(fileService.containsFile(collectionId, "some/file.txt"))
+  }
+
+  @Test
+  fun `ignore if file is moved to its own directory`() {
+    fileService.createDirectories(collectionId, setOf("some"))
+    fileService.createFiles(collectionId, setOf("some/file.txt"))
+    fileService.moveFile(collectionId, setOf("some/file.txt"), "some")
+    assertTrue(fileService.containsFile(collectionId, "some/file.txt"))
+  }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -52,11 +52,8 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `lists no files or directories that do not exist`() {
-    assertNull(fileService.walkFileTree(collectionId).find { it.path == "/file.txt" })
-    assertNull(fileService.walkFileTree(collectionId).find { it.path == "/some/path" })
-    assertNull(fileService.listFiles(collectionId, "/").find { it.path == "/file.txt" })
-    assertNull(fileService.listFiles(collectionId, "/some").find { it.path == "/path" })
+  fun `root dir does always exist with no files`() {
+    assertTrue(fileService.listFiles(collectionId, "/").count() == 0)
   }
 
   @Test
@@ -115,11 +112,6 @@ class JpaFileServiceTest {
   fun `creating a file throws when the path already exists`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
     fileService.createFiles(collectionId, setOf("file.txt")) // Throws because file already exists
-  }
-
-  @Test(expected = IllegalArgumentException::class)
-  fun `creating a file two times at once throws`() {
-    fileService.createFiles(collectionId, setOf("file.txt", "file.txt"))
   }
 
   @Test(expected = IllegalArgumentException::class)

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -293,7 +293,7 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `writes file contents correctly`() {
+  fun `writes and reads file contents correctly`() {
     val contents = byteArrayOf(42)
     fileService.createFiles(collectionId, setOf("file.txt"))
 
@@ -333,6 +333,24 @@ class JpaFileServiceTest {
     fileService.writeFile(collectionId, "file.txt").use {
       it.write(byteArrayOf(42))
     }
+  }
+
+  @Test
+  fun `reads an existing empty file`() {
+    fileService.createFiles(collectionId, setOf("file.txt"))
+    assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), byteArrayOf()))
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `reading file contents throws for directories`() {
+    fileService.createDirectories(collectionId, setOf("some/path"))
+
+    fileService.readFile(collectionId, "some/path")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `reading file contents throws if path does not exist`() {
+    fileService.readFile(collectionId, "file.txt")
   }
 
   @Test

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -5,6 +5,7 @@ import java.util.Optional
 import java.util.UUID
 import org.codefreak.codefreak.entity.FileCollection
 import org.codefreak.codefreak.repository.FileCollectionRepository
+import org.codefreak.codefreak.service.file.FileService
 import org.codefreak.codefreak.service.file.JpaFileService
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -21,7 +22,7 @@ class JpaFileServiceTest {
   @Mock
   lateinit var fileCollectionRepository: FileCollectionRepository
   @InjectMocks
-  val fileService = JpaFileService()
+  val fileService: FileService = JpaFileService()
 
   @Before
   fun init() {
@@ -85,6 +86,40 @@ class JpaFileServiceTest {
     assertTrue(fileService.containsFile(collectionId, "other.txt"))
     assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
     assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+  }
+
+  @Test
+  fun `finds an existing file`() {
+    fileService.createFiles(collectionId, setOf("file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file.txt"))
+  }
+
+  @Test
+  fun `does not find not-existing files`() {
+    assertFalse(fileService.containsFile(collectionId, "file.txt"))
+  }
+
+  @Test
+  fun `does not find file if the path is a directory`() {
+    fileService.createDirectories(collectionId, setOf("some/path"))
+    assertFalse(fileService.containsFile(collectionId, "some/path"))
+  }
+
+  @Test
+  fun `finds an existing directory`() {
+    fileService.createDirectories(collectionId, setOf("some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+  }
+
+  @Test
+  fun `does not find not-existing directories`() {
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+  }
+
+  @Test
+  fun `does not find directory if the path is a file`() {
+    fileService.createFiles(collectionId, setOf("file.txt"))
+    assertFalse(fileService.containsDirectory(collectionId, "file.txt"))
   }
 
   @Test

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -32,24 +32,24 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `createFile creates an empty file`() {
+  fun `creates an empty file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
     assertTrue(fileService.containsFile(collectionId, "file.txt"))
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `createFile throws when the path already exists`() {
+  fun `creating a file throws when the path already exists`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
     fileService.createFiles(collectionId, setOf("file.txt")) // Throws because file already exists
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `createFile throws on empty path name`() {
+  fun `creating a file throws on empty path name`() {
     fileService.createFiles(collectionId, setOf(""))
   }
 
   @Test
-  fun `createFile keeps other files intact`() {
+  fun `creating a file keeps other files intact`() {
     fileService.createFiles(collectionId, setOf("other.txt"))
     fileService.createDirectories(collectionId, setOf("aDirectory"))
     fileService.createFiles(collectionId, setOf("file.txt"))
@@ -60,24 +60,24 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `createDirectory creates an empty directory`() {
+  fun `creates an empty directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
     assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `createDirectory throws when the path already exists`() {
+  fun `creating a directory throws when the path already exists`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createDirectories(collectionId, setOf("some/path")) // Throws because directory already exists
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `createDirectory throws on empty path name`() {
+  fun `creating a directory throws on empty path name`() {
     fileService.createFiles(collectionId, setOf(""))
   }
 
   @Test
-  fun `createDirectory keeps other files intact`() {
+  fun `creating a directory keeps other files intact`() {
     fileService.createFiles(collectionId, setOf("other.txt"))
     fileService.createDirectories(collectionId, setOf("aDirectory"))
     fileService.createDirectories(collectionId, setOf("some/path"))
@@ -88,7 +88,7 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `deleteFile deletes existing file`() {
+  fun `deletes an existing file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
 
     fileService.deleteFiles(collectionId, setOf("file.txt"))
@@ -97,12 +97,12 @@ class JpaFileServiceTest {
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `deleteFile throws when path does not exist`() {
+  fun `deleting a file throws when path does not exist`() {
     fileService.deleteFiles(collectionId, setOf("file.txt"))
   }
 
   @Test
-  fun `deleteFile keeps other files and directories intact when deleting a file`() {
+  fun `keeps other files and directories intact when deleting a file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
     fileService.createFiles(collectionId, setOf("DO_NOT_DELETE.txt"))
     fileService.createDirectories(collectionId, setOf("some/path"))
@@ -115,7 +115,7 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `deleteFile deletes existing directory`() {
+  fun `deletes existing directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
 
     fileService.deleteFiles(collectionId, setOf("some/path"))
@@ -124,7 +124,7 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `deleteFile keeps other files and directories intact when deleting a directory`() {
+  fun `keeps other files and directories intact when deleting a directory`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
     fileService.createDirectories(collectionId, setOf("DO_NOT_DELETE"))
     fileService.createDirectories(collectionId, setOf("some/path"))
@@ -137,7 +137,7 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `deleteFile deletes directory content recursively`() {
+  fun `deletes directory content recursively`() {
     val directoryToDelete = "some/path"
     val fileToRecursivelyDelete = "some/path/file.txt"
     val directoryToRecursivelyDelete = "some/path/some/path"
@@ -157,7 +157,7 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `filePutContents puts the file contents correctly`() {
+  fun `writes file contents correctly`() {
     val contents = byteArrayOf(42)
     fileService.createFiles(collectionId, setOf("file.txt"))
 
@@ -184,7 +184,7 @@ class JpaFileServiceTest {
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `filePutContents throws for directories`() {
+  fun `writing file contents throws for directories`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
 
     fileService.writeFile(collectionId, "some/path").use {
@@ -193,14 +193,14 @@ class JpaFileServiceTest {
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `filePutContents throws if path does not exist`() {
+  fun `writing file contents throws if path does not exist`() {
     fileService.writeFile(collectionId, "file.txt").use {
       it.write(byteArrayOf(42))
     }
   }
 
   @Test
-  fun `moveFile moves existing file`() {
+  fun `moves existing file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
 
     fileService.moveFile(collectionId, setOf("file.txt"), "new.txt")
@@ -210,12 +210,12 @@ class JpaFileServiceTest {
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `moveFile throws when source path does not exist`() {
+  fun `moving a file throws when source path does not exist`() {
     fileService.moveFile(collectionId, setOf("file.txt"), "new.txt")
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `moveFile throws when target file path already exists`() {
+  fun `moving a file throws when target file path already exists`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
     fileService.createFiles(collectionId, setOf("new.txt"))
 
@@ -223,7 +223,7 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `moveFile does not change file contents`() {
+  fun `moving a file does not change file contents`() {
     val contents = byteArrayOf(42)
     fileService.createFiles(collectionId, setOf("file.txt"))
     fileService.writeFile(collectionId, "file.txt").use {
@@ -236,7 +236,7 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `moveFile moves existing directory`() {
+  fun `moves existing directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
 
     fileService.moveFile(collectionId, setOf("some/path"), "new")
@@ -246,7 +246,7 @@ class JpaFileServiceTest {
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `moveFile throws when source directory is moved to itself`() {
+  fun `moving a directory throws when source directory is moved to itself`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createDirectories(collectionId, setOf("some/path/inner"))
 
@@ -254,7 +254,7 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `moveFile moves inner hierarchy correctly`() {
+  fun `moving a directory moves inner hierarchy correctly`() {
     val innerDirectory = "some/path/inner"
     val innerFile1 = "some/path/inner/file.txt"
     val innerFile1Contents = byteArrayOf(42)

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -249,11 +249,10 @@ class JpaFileServiceTest {
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `moveFile throws when target directory path already exists`() {
+  fun `moveFile throws when source directory is moved to itself`() {
     createDirectory(directoryPath)
-    createDirectory("new")
-
-    moveFile(directoryPath, "new")
+    createDirectory("$directoryPath/inner")
+    moveFile(directoryPath, "$directoryPath/inner")
   }
 
   @Test
@@ -289,19 +288,19 @@ class JpaFileServiceTest {
     assertTrue(equals(getFileContents("new/$filePath").readBytes(), innerFile2Contents))
   }
 
-  private fun createFile(path: String) = fileService.createFile(collectionId, path)
+  private fun createFile(path: String) = fileService.createFiles(collectionId, setOf(path))
 
-  private fun createDirectory(path: String) = fileService.createDirectory(collectionId, path)
+  private fun createDirectory(path: String) = fileService.createDirectories(collectionId, setOf(path))
 
-  private fun deleteFile(path: String) = fileService.deleteFile(collectionId, path)
+  private fun deleteFile(path: String) = fileService.deleteFiles(collectionId, setOf(path))
 
   private fun containsFile(path: String): Boolean = fileService.containsFile(collectionId, path)
 
   private fun containsDirectory(path: String): Boolean = fileService.containsDirectory(collectionId, path)
 
-  private fun filePutContents(path: String) = fileService.filePutContents(collectionId, path)
+  private fun filePutContents(path: String) = fileService.writeFile(collectionId, path)
 
-  private fun getFileContents(path: String): InputStream = fileService.getFileContents(collectionId, path)
+  private fun getFileContents(path: String): InputStream = fileService.readFile(collectionId, path)
 
-  private fun moveFile(from: String, to: String) = fileService.moveFile(collectionId, from, to)
+  private fun moveFile(from: String, to: String) = fileService.moveFile(collectionId, setOf(from), to)
 }

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -619,9 +619,15 @@ class JpaFileServiceTest {
 
   @Test
   fun `ignore if file is moved to its own directory`() {
-    fileService.createDirectories(collectionId, setOf("some"))
-    fileService.createFiles(collectionId, setOf("some/file.txt"))
-    fileService.moveFile(collectionId, setOf("some/file.txt"), "some")
-    assertTrue(fileService.containsFile(collectionId, "some/file.txt"))
+    fileService.createFiles(collectionId, setOf("file.txt"))
+    fileService.createFiles(collectionId, setOf("file2.txt"))
+    fileService.moveFile(collectionId, setOf("file.txt", "file2.txt"), "/")
+    assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file2.txt"))
+
+    fileService.createDirectories(collectionId, setOf("subdir"))
+    fileService.createFiles(collectionId, setOf("subdir/file.txt"))
+    fileService.moveFile(collectionId, setOf("subdir/file.txt"), "subdir")
+    assertTrue(fileService.containsFile(collectionId, "subdir/file.txt"))
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -102,10 +102,18 @@ class JpaFileServiceTest {
     assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
-  @Test(expected = IllegalArgumentException::class)
-  fun `creating a directory throws when the path already exists`() {
+  @Test
+  fun `creates multiple directories`() {
+    fileService.createDirectories(collectionId, setOf("some/path", "some/other/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/other/path"))
+  }
+
+  @Test
+  fun `creating a ignores silently when the directory already exists`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    fileService.createDirectories(collectionId, setOf("some/path")) // Throws because directory already exists
+    fileService.createDirectories(collectionId, setOf("some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test(expected = IllegalArgumentException::class)
@@ -122,6 +130,18 @@ class JpaFileServiceTest {
     assertTrue(fileService.containsFile(collectionId, "other.txt"))
     assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
     assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+  }
+
+  @Test
+  fun `creating multiple directories keeps other files intact`() {
+    fileService.createFiles(collectionId, setOf("other.txt"))
+    fileService.createDirectories(collectionId, setOf("aDirectory"))
+    fileService.createDirectories(collectionId, setOf("some/path", "some/other/path"))
+
+    assertTrue(fileService.containsFile(collectionId, "other.txt"))
+    assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/other/path"))
   }
 
   @Test

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -111,7 +111,7 @@ class JpaFileServiceTest {
   }
 
   @Test
-  fun `creating a ignores silently when the directory already exists`() {
+  fun `creating a directory ignores silently when the directory already exists`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createDirectories(collectionId, setOf("some/path"))
     assertTrue(fileService.containsDirectory(collectionId, "some/path"))

--- a/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/JpaFileServiceTest.kt
@@ -601,4 +601,11 @@ class JpaFileServiceTest {
     assertTrue(fileService.containsFile(collectionId, "new/file.txt"))
     assertTrue(equals(fileService.readFile(collectionId, "new/file.txt").readBytes(), innerFile2Contents))
   }
+
+  @Test
+  fun `moving from child to parent directory`() {
+    fileService.createDirectories(collectionId, setOf("some/path"))
+    fileService.moveFile(collectionId, setOf("some/path"), "/")
+    assertTrue(fileService.containsDirectory(collectionId, "path"))
+  }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
This PR improves the (currently unused) new file API in preparation for the new file manager.
Most important changes:
* Make file-listing non-recursive
* Give some additional information about file/dir when listing directory content
* Support batch operations for move/delete
* Close all  I/O streams properly

The next steps will be (in upcoming PRs):
* Move the files from database to filesystem (Drop the JpaFileService... this will remove A LOT of code for tar-file handling)
* Integrate the new file manager
* Drop the FileContentService
* Drop the old GraphQL file API

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [x] I have added tests that prove my fix is effective or that my feature works
