### PR TITLE
Create explicit rename API

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/graphql/api/FileApi.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/graphql/api/FileApi.kt
@@ -136,6 +136,12 @@ class FileMutation : BaseResolver(), Mutation {
     true
   }
 
+  fun renameFile(fileContext: FileContext, source: String, target: String): Boolean = context {
+    authorize(fileContext)
+    serviceAccess.getService(FileService::class).renameFile(fileContext.id, source, target)
+    true
+  }
+
   fun deleteFiles(fileContext: FileContext, paths: List<String>): Boolean = context {
     authorize(fileContext)
     serviceAccess.getService(FileService::class).deleteFiles(fileContext.id, paths.toSet())

--- a/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/file/FileService.kt
@@ -70,13 +70,20 @@ interface FileService {
   fun deleteFiles(collectionId: UUID, paths: Set<String>)
 
   /**
+   * Rename a file or directory to target.
+   *  - Path must be an existing file or directory
+   *  - Target must not exist
+   *  - If source is a directory the full structure inside this directory will be preserved in target
+   *
+   * If one of the conditions above does not match an IllegalArgumentException is thrown.
+   */
+  @Throws(IllegalArgumentException::class)
+  fun renameFile(collectionId: UUID, source: String, target: String)
+
+  /**
    * Move one or multiple source files to target.
-   * The behaviour depends on the type of target.
-   * - Always:
+   * The behaviour is as follows:
    *   - All sources must be existing files or directories
-   * - If target does not exist (renaming a single file/directory):
-   *   - Only a single source is allowed
-   * - If target does exist (moving multiple files/dir to a folder):
    *   - Target must be an existing directory
    *   - One or multiple files are allowed
    *   - Target must not be one of the descendants of source (moving something to itself)


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
Moving files had an undesired side-effect when renaming a file to an
already existing directory name. E.g. /file.txt to /dir if /dir is an
existing directory. This caused /file.txt to be moved to /dir but this
is undesired in cases where you really want to rename. This is why I
created an explicit API for renaming files. So move means moving things
to a directory now and rename is a 1:1 renaming of a file/directory to a
new name.

## :link: Related Issues
* Fixes # (issue)

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [x] I have added tests that prove my fix is effective or that my feature works
