### PR TITLE
Add support for CodeClimate location.positions format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
+* Add support for CodeClimate `location.positions` format
 
 ### Changed
 

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/runner/CodeclimateRunner.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/runner/CodeclimateRunner.kt
@@ -58,8 +58,10 @@ class CodeclimateRunner : AbstractDockerRunner() {
         severity = CODECLIMATE_SEVERITY_MAP[issue.severity]
         fileContext = FileContext(
             issue.location.path,
-            lineStart = issue.location.lines.begin,
-            lineEnd = issue.location.lines.end
+            lineStart = issue.location.lines?.begin ?: issue.location.positions?.begin?.line,
+            lineEnd = issue.location.lines?.end ?: issue.location.positions?.end?.line,
+            columnStart = issue.location.positions?.begin?.column,
+            columnEnd = issue.location.positions?.end?.column
         )
       }
     }
@@ -126,15 +128,26 @@ class CodeclimateRunner : AbstractDockerRunner() {
       var body = ""
     }
 
-    // TODO support other location formats (needs custom deserializer)
-    //      see https://github.com/codeclimate/spec/blob/master/SPEC.md#locations
     class Location {
       var path = ""
-      var lines = Lines()
+      var lines: Lines? = null
+      var positions: Positions? = null
 
       class Lines {
         var begin = 0
         var end = 0
+      }
+
+      class Positions {
+        var begin: Position? = null
+        var end: Position? = null
+      }
+
+      // TODO: support "offset" position type
+      // https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#positions
+      class Position {
+        var line: Int? = null
+        var column: Int? = null
       }
     }
   }


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] New feature (non-breaking change which adds functionality)


## :scroll: Description
What's still missing is support for `Position.offset`. Haven't found a plugin that uses this format, yet.

## :link: Related Issues
* Fixes # (issue)

## :ballot_box_with_check: Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
