### PR TITLE
Add service to hook into the shutdown of the backend in dev mode and clean up all file-collections

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/service/CleanupDevFileSystemService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/CleanupDevFileSystemService.kt
@@ -2,6 +2,7 @@ package org.codefreak.codefreak.service
 
 import java.util.UUID
 import javax.annotation.PreDestroy
+import javax.sql.DataSource
 import org.codefreak.codefreak.Env
 import org.codefreak.codefreak.repository.AnswerRepository
 import org.codefreak.codefreak.repository.TaskRepository
@@ -29,10 +30,18 @@ class CleanupDevFileSystemService {
   @Autowired
   lateinit var answerRepository: AnswerRepository
 
+  @Autowired
+  lateinit var dataSource: DataSource
+
   private val log = LoggerFactory.getLogger(this::class.java)
 
   @PreDestroy
   fun cleanupFileCollections() {
+    if (!isInMemoryDatabase(dataSource)) {
+      log.info("Not cleaning-up any file collections since no in-memory database is in use")
+      return
+    }
+
     val fileCollectionIds = mutableListOf<UUID>()
 
     taskRepository.findAll().forEach { fileCollectionIds.add(it.id) }
@@ -43,5 +52,16 @@ class CleanupDevFileSystemService {
     }
 
     log.info("Cleaned up ${fileCollectionIds.size} file collections from disk")
+  }
+
+  private fun isInMemoryDatabase(dataSource: DataSource): Boolean {
+    val url = dataSource.connection.metaData.url
+
+    val isInMemoryH2Database = url.startsWith("jdbc:h2:mem")
+    val isInMemoryHsqlDatabase = url.startsWith("jdbc:hsqldb:mem")
+    val isInMemoryDerbyDatabase = url.startsWith("jdbc:derby:memory")
+    val isInMemorySqliteDatabase = url.startsWith("jdbc:sqlite:memory")
+
+    return isInMemoryH2Database || isInMemoryHsqlDatabase || isInMemoryDerbyDatabase || isInMemorySqliteDatabase
   }
 }

--- a/src/main/kotlin/org/codefreak/codefreak/service/CleanupDevFileSystemService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/CleanupDevFileSystemService.kt
@@ -1,0 +1,47 @@
+package org.codefreak.codefreak.service
+
+import java.util.UUID
+import javax.annotation.PreDestroy
+import org.codefreak.codefreak.Env
+import org.codefreak.codefreak.repository.AnswerRepository
+import org.codefreak.codefreak.repository.TaskRepository
+import org.codefreak.codefreak.service.file.FileService
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Profile
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Service
+
+@Service
+@Profile(Env.DEV)
+@Order(Ordered.LOWEST_PRECEDENCE)
+@ConditionalOnProperty(name = ["codefreak.files.adapter"], havingValue = "FILE_SYSTEM")
+class CleanupDevFileSystemService {
+
+  @Autowired
+  lateinit var fileService: FileService
+
+  @Autowired
+  lateinit var taskRepository: TaskRepository
+
+  @Autowired
+  lateinit var answerRepository: AnswerRepository
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @PreDestroy
+  fun cleanupFileCollections() {
+    val fileCollectionIds = mutableListOf<UUID>()
+
+    taskRepository.findAll().forEach { fileCollectionIds.add(it.id) }
+    answerRepository.findAll().forEach { fileCollectionIds.add(it.id) }
+
+    fileCollectionIds.forEach {
+      fileService.deleteCollection(it)
+    }
+
+    log.info("Cleaned up ${fileCollectionIds.size} file collections from disk")
+  }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
When running the backend in dev mode and using the file-system for storing the file-collections those files are not deleted when shutting down the backend. Since an in-memory database is used all connections to those files are erased but the files clutter up the system. The solution is to delete all file-collections on the file-system in a `pre-destroy` hook.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
