### PR TITLE
Delete corresponding file-collections when deleting answers and tasks

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/service/AnswerService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/AnswerService.kt
@@ -60,6 +60,10 @@ class AnswerService : BaseService() {
   fun deleteAnswer(answerId: UUID) {
     ideService.removeAnswerIdeContainers(answerId)
     answerRepository.deleteById(answerId)
+
+    if (fileService.collectionExists(answerId)) {
+      fileService.deleteCollection(answerId)
+    }
   }
 
   @Transactional

--- a/src/main/kotlin/org/codefreak/codefreak/service/TaskService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/TaskService.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 import org.codefreak.codefreak.entity.Task
 import org.codefreak.codefreak.repository.AssignmentRepository
 import org.codefreak.codefreak.repository.TaskRepository
+import org.codefreak.codefreak.service.file.FileService
 import org.codefreak.codefreak.util.PositionUtil
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
@@ -20,6 +21,9 @@ TaskService : BaseService() {
   @Autowired
   private lateinit var assignmentRepository: AssignmentRepository
 
+  @Autowired
+  private lateinit var fileService: FileService
+
   @Transactional
   fun findTask(id: UUID): Task = taskRepository.findById(id)
       .orElseThrow { EntityNotFoundException("Task not found") }
@@ -31,6 +35,10 @@ TaskService : BaseService() {
       taskRepository.saveAll(tasks)
     }
     taskRepository.delete(task)
+
+    if (fileService.collectionExists(task.id)) {
+      fileService.deleteCollection(task.id)
+    }
   }
 
   @Transactional


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
When deleting an answer or tasks the corresponding file-collections were deleted through the cascade in the database. But when using the file-system as a storage provider the file-collections still remain and thus have to be deleted manually.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
