### PR TITLE
Fix broken zip exports

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/TarUtil.kt
@@ -71,12 +71,15 @@ object TarUtil {
     val tar = TarArchiveInputStream(`in`)
     val zip = ZipArchiveOutputStream(out)
     generateSequence { tar.nextTarEntry }.forEach { tarEntry ->
-      val zipEntry = ZipArchiveEntry(FileUtil.sanitizeName(tarEntry.name))
       if (tarEntry.isFile) {
+        val zipEntry = ZipArchiveEntry(FileUtil.sanitizeName(tarEntry.name))
         zipEntry.size = tarEntry.size
         zip.putArchiveEntry(zipEntry)
         IOUtils.copy(tar, zip)
       } else {
+        // A ZipArchiveEntry is interpreted as a directory "if and only if it ends with a forward slash"
+        val nameWithTrailingSlash = FileUtil.sanitizeName(tarEntry.name) + "/"
+        val zipEntry = ZipArchiveEntry(nameWithTrailingSlash)
         zip.putArchiveEntry(zipEntry)
       }
       zip.closeArchiveEntry()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
When exporting a zip file the directories were shown as files and the zip file was marked as corrupt. This was because the `ZipArchiveEntry` expected a trailing slash for directories, which were trimmed through `FileUtil::sanitizeName`.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
