### PR TITLE
Migrate to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,13 @@ release {
 //project.tasks.preTagCommit.dependsOn ":client:updateVersionFromGradle"
 //project.tasks.commitNewVersion.dependsOn ":client:updateVersionFromGradle"
 
+configurations {
+  testImplementation {
+    // make sure we are not using jUnit 4 accidentally
+    exclude group: 'junit', module: 'junit'
+  }
+}
+
 dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-aop'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -78,7 +85,6 @@ dependencies {
   runtimeOnly 'org.postgresql:postgresql'
   runtimeOnly 'org.hsqldb:hsqldb'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
-  testImplementation 'org.springframework.batch:spring-batch-test'
   testImplementation 'org.springframework.security:spring-security-test'
   testImplementation 'org.hamcrest:hamcrest:2.2'
   testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
@@ -158,6 +164,7 @@ springBoot {
 }
 
 test {
+  useJUnitPlatform()
   testLogging {
     events "failed"
     exceptionFormat "full"

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ release {
 
 configurations {
   testImplementation {
-    // make sure we are not using jUnit 4 accidentally
+    // make sure we are not using JUnit 4 accidentally
     exclude group: 'junit', module: 'junit'
   }
 }

--- a/src/main/kotlin/org/codefreak/codefreak/CodeFreakApplication.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/CodeFreakApplication.kt
@@ -9,10 +9,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.EnableAspectJAutoProxy
 import org.springframework.scheduling.annotation.EnableAsync
-import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
-@EnableScheduling
 @EnableAsync
 @EnableAspectJAutoProxy
 @EnableBatchProcessing

--- a/src/main/kotlin/org/codefreak/codefreak/config/SchedulingConfiguration.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/config/SchedulingConfiguration.kt
@@ -1,13 +1,15 @@
 package org.codefreak.codefreak.config
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
 
+@ConditionalOnProperty(value = ["codefreak.scheduling.enable"], havingValue = "true", matchIfMissing = true)
 @Configuration
-@Profile("!test")
-class TaskSchedulerConfiguration {
+@EnableScheduling
+class SchedulingConfiguration {
   @Bean
   fun threadPoolTaskScheduler(): ThreadPoolTaskScheduler {
     val threadPoolTaskScheduler = ThreadPoolTaskScheduler()

--- a/src/main/kotlin/org/codefreak/codefreak/service/AssignmentStatusChangePublisher.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/AssignmentStatusChangePublisher.kt
@@ -11,6 +11,7 @@ import org.codefreak.codefreak.entity.AssignmentStatus
 import org.codefreak.codefreak.entity.EntityListener
 import org.codefreak.codefreak.repository.AssignmentRepository
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.ContextRefreshedEvent
@@ -21,6 +22,7 @@ import org.springframework.scheduling.TaskScheduler
 import org.springframework.stereotype.Component
 
 @Component
+@ConditionalOnBean(TaskScheduler::class)
 @EntityListener(Assignment::class)
 class AssignmentStatusChangePublisher {
   @Autowired

--- a/src/main/kotlin/org/codefreak/codefreak/service/SubmissionDeadlinePublisher.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/SubmissionDeadlinePublisher.kt
@@ -11,6 +11,7 @@ import org.codefreak.codefreak.entity.Submission
 import org.codefreak.codefreak.repository.AssignmentRepository
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.ContextRefreshedEvent
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 @Component
+@ConditionalOnBean(TaskScheduler::class)
 @EntityListener(Submission::class)
 class SubmissionDeadlinePublisher {
   companion object {

--- a/src/test/kotlin/org/codefreak/codefreak/CodeFreakApplicationTests.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/CodeFreakApplicationTests.kt
@@ -1,6 +1,6 @@
 package org.codefreak.codefreak
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class CodeFreakApplicationTests : SpringTest() {
 

--- a/src/test/kotlin/org/codefreak/codefreak/SpringTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/SpringTest.kt
@@ -11,13 +11,13 @@ import org.codefreak.codefreak.repository.AssignmentRepository
 import org.codefreak.codefreak.repository.SubmissionRepository
 import org.codefreak.codefreak.repository.TaskRepository
 import org.codefreak.codefreak.repository.UserRepository
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @SpringBootTest
 @ActiveProfiles("test")
 abstract class SpringTest {

--- a/src/test/kotlin/org/codefreak/codefreak/arch/ArchitectureTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/arch/ArchitectureTest.kt
@@ -3,17 +3,14 @@ package org.codefreak.codefreak.arch
 import com.tngtech.archunit.core.importer.ImportOption
 import com.tngtech.archunit.junit.AnalyzeClasses
 import com.tngtech.archunit.junit.ArchTest
-import com.tngtech.archunit.junit.ArchUnitRunner
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition
 import com.tngtech.archunit.library.Architectures
 import javax.inject.Named
 import javax.persistence.ManyToMany
 import javax.persistence.OneToMany
-import org.junit.runner.RunWith
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
-@RunWith(ArchUnitRunner::class)
 @AnalyzeClasses(packages = ["org.codefreak.codefreak"], importOptions = [ImportOption.DoNotIncludeTests::class])
 internal class ArchitectureTest {
 

--- a/src/test/kotlin/org/codefreak/codefreak/auth/AuthorizationTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/auth/AuthorizationTest.kt
@@ -4,7 +4,7 @@ import org.codefreak.codefreak.SpringFrontendTest
 import org.codefreak.codefreak.frontend.BaseController
 import org.codefreak.codefreak.service.SeedDummyUsersService
 import org.codefreak.codefreak.service.UserService
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.springframework.security.access.annotation.Secured
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService

--- a/src/test/kotlin/org/codefreak/codefreak/auth/LtiAuthTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/auth/LtiAuthTest.kt
@@ -4,8 +4,8 @@ import com.nhaarman.mockitokotlin2.any
 import org.codefreak.codefreak.SpringFrontendTest
 import org.codefreak.codefreak.auth.lti.LtiAuthenticationFilter
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mitre.jwt.signer.service.JWTSigningAndValidationService
 import org.mitre.jwt.signer.service.impl.JWKSetCacheService
 import org.mitre.openid.connect.client.service.ServerConfigurationService
@@ -24,7 +24,7 @@ class LtiAuthTest : SpringFrontendTest() {
   @Autowired
   lateinit var ltiAuthenticationFilter: LtiAuthenticationFilter
 
-  @Before
+  @BeforeEach
   fun before() {
     ltiAuthenticationFilter.restClient = Mockito.mock(RestTemplate::class.java)
     val mockValidator = Mockito.mock(JWTSigningAndValidationService::class.java)

--- a/src/test/kotlin/org/codefreak/codefreak/entity/AnswerTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/entity/AnswerTest.kt
@@ -1,15 +1,14 @@
 package org.codefreak.codefreak.entity
 
 import com.nhaarman.mockitokotlin2.whenever
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.junit.jupiter.MockitoExtension
 
-@RunWith(MockitoJUnitRunner::class)
+@ExtendWith(MockitoExtension::class)
 class AnswerTest {
   @Mock
   lateinit var assignment: Assignment
@@ -25,28 +24,28 @@ class AnswerTest {
 
   @Test
   fun `answer is editable by default`() {
-    assertTrue(answer.isEditable)
+    Assertions.assertTrue(answer.isEditable)
   }
 
   @Test
   fun `answer is editable by default if task has no assignment`() {
-    assertTrue(answer.isEditable)
+    Assertions.assertTrue(answer.isEditable)
   }
 
   @Test
   fun `answer is editable only if assignment is open`() {
     whenever(assignment.status).thenReturn(AssignmentStatus.OPEN)
     whenever(task.assignment).thenReturn(assignment)
-    assertTrue(answer.isEditable)
+    Assertions.assertTrue(answer.isEditable)
     whenever(assignment.status).thenReturn(AssignmentStatus.CLOSED)
-    assertFalse(answer.isEditable)
+    Assertions.assertFalse(answer.isEditable)
   }
 
   @Test
   fun `answer is not editable if deadline has been reached`() {
     whenever(submission.deadlineReached).thenReturn(true)
-    assertFalse(answer.isEditable)
+    Assertions.assertFalse(answer.isEditable)
     whenever(submission.deadlineReached).thenReturn(false)
-    assertTrue(answer.isEditable)
+    Assertions.assertTrue(answer.isEditable)
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/entity/AnswerTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/entity/AnswerTest.kt
@@ -1,7 +1,8 @@
 package org.codefreak.codefreak.entity
 
 import com.nhaarman.mockitokotlin2.whenever
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -24,28 +25,28 @@ class AnswerTest {
 
   @Test
   fun `answer is editable by default`() {
-    Assertions.assertTrue(answer.isEditable)
+    assertTrue(answer.isEditable)
   }
 
   @Test
   fun `answer is editable by default if task has no assignment`() {
-    Assertions.assertTrue(answer.isEditable)
+    assertTrue(answer.isEditable)
   }
 
   @Test
   fun `answer is editable only if assignment is open`() {
     whenever(assignment.status).thenReturn(AssignmentStatus.OPEN)
     whenever(task.assignment).thenReturn(assignment)
-    Assertions.assertTrue(answer.isEditable)
+    assertTrue(answer.isEditable)
     whenever(assignment.status).thenReturn(AssignmentStatus.CLOSED)
-    Assertions.assertFalse(answer.isEditable)
+    assertFalse(answer.isEditable)
   }
 
   @Test
   fun `answer is not editable if deadline has been reached`() {
     whenever(submission.deadlineReached).thenReturn(true)
-    Assertions.assertFalse(answer.isEditable)
+    assertFalse(answer.isEditable)
     whenever(submission.deadlineReached).thenReturn(false)
-    Assertions.assertTrue(answer.isEditable)
+    assertTrue(answer.isEditable)
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/entity/BaseEntityTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/entity/BaseEntityTest.kt
@@ -1,11 +1,8 @@
 package org.codefreak.codefreak.entity
 
 import java.util.UUID
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 internal class BaseEntityTest {
   companion object {
@@ -19,31 +16,31 @@ internal class BaseEntityTest {
 
   @Test
   fun `entity and null are not equal`() {
-    assertFalse(entity.equals(null))
+    Assertions.assertFalse(entity.equals(null))
   }
 
   @Test
   fun `entity and other object are not equal`() {
-    assertFalse(entity.equals("foo"))
+    Assertions.assertFalse(entity.equals("foo"))
   }
 
   @Test
   fun `entity and itself are equal`() {
-    assertTrue(entity.equals(entity))
-    assertEquals(entity.hashCode(), entity.hashCode())
+    Assertions.assertTrue(entity.equals(entity))
+    Assertions.assertEquals(entity.hashCode(), entity.hashCode())
   }
 
   @Test
   fun `entities with different id are not equal`() {
     val other = StubEntity(ID2)
-    assertFalse(entity.equals(other))
-    assertNotEquals(entity.hashCode(), other.hashCode())
+    Assertions.assertFalse(entity.equals(other))
+    Assertions.assertNotEquals(entity.hashCode(), other.hashCode())
   }
 
   @Test
   fun `entities with same id are equal`() {
     val other = StubEntity(ID1)
-    assertTrue(entity.equals(other))
-    assertEquals(entity.hashCode(), other.hashCode())
+    Assertions.assertTrue(entity.equals(other))
+    Assertions.assertEquals(entity.hashCode(), other.hashCode())
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/entity/BaseEntityTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/entity/BaseEntityTest.kt
@@ -1,7 +1,10 @@
 package org.codefreak.codefreak.entity
 
 import java.util.UUID
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class BaseEntityTest {
@@ -16,31 +19,31 @@ internal class BaseEntityTest {
 
   @Test
   fun `entity and null are not equal`() {
-    Assertions.assertFalse(entity.equals(null))
+    assertFalse(entity.equals(null))
   }
 
   @Test
   fun `entity and other object are not equal`() {
-    Assertions.assertFalse(entity.equals("foo"))
+    assertFalse(entity.equals("foo"))
   }
 
   @Test
   fun `entity and itself are equal`() {
-    Assertions.assertTrue(entity.equals(entity))
-    Assertions.assertEquals(entity.hashCode(), entity.hashCode())
+    assertTrue(entity.equals(entity))
+    assertEquals(entity.hashCode(), entity.hashCode())
   }
 
   @Test
   fun `entities with different id are not equal`() {
     val other = StubEntity(ID2)
-    Assertions.assertFalse(entity.equals(other))
-    Assertions.assertNotEquals(entity.hashCode(), other.hashCode())
+    assertFalse(entity.equals(other))
+    assertNotEquals(entity.hashCode(), other.hashCode())
   }
 
   @Test
   fun `entities with same id are equal`() {
     val other = StubEntity(ID1)
-    Assertions.assertTrue(entity.equals(other))
-    Assertions.assertEquals(entity.hashCode(), other.hashCode())
+    assertTrue(entity.equals(other))
+    assertEquals(entity.hashCode(), other.hashCode())
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/entity/SubmissionTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/entity/SubmissionTest.kt
@@ -3,15 +3,15 @@ package org.codefreak.codefreak.entity
 import com.nhaarman.mockitokotlin2.whenever
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.junit.jupiter.MockitoExtension
 
-@RunWith(MockitoJUnitRunner::class)
+@ExtendWith(MockitoExtension::class)
 class SubmissionTest {
   @Mock
   lateinit var user: User
@@ -22,7 +22,7 @@ class SubmissionTest {
   @InjectMocks
   lateinit var submission: Submission
 
-  @Before
+  @BeforeEach
   fun init() {
     whenever(assignment.deadline).thenReturn(null)
     whenever(assignment.timeLimit).thenReturn(null)
@@ -30,20 +30,20 @@ class SubmissionTest {
 
   @Test
   fun `no deadline if neither assignment has deadline nor submission has time limit`() {
-    Assert.assertNull(submission.deadline)
+    Assertions.assertNull(submission.deadline)
   }
 
   @Test
   fun `use assignment deadline if no time limit is set`() {
     val deadline = Instant.now()
     whenever(assignment.deadline).thenReturn(deadline)
-    Assert.assertEquals(deadline, submission.deadline)
+    Assertions.assertEquals(deadline, submission.deadline)
   }
 
   @Test
   fun `use time limit if assignment has no deadline`() {
     whenever(assignment.timeLimit).thenReturn(30L)
-    Assert.assertEquals(
+    Assertions.assertEquals(
         submission.createdAt.plusSeconds(30).truncatedTo(ChronoUnit.SECONDS),
         submission.deadline?.truncatedTo(ChronoUnit.SECONDS)
     )
@@ -55,7 +55,7 @@ class SubmissionTest {
     val deadline = submission.createdAt.plusSeconds(60)
     whenever(assignment.deadline).thenReturn(deadline)
     whenever(assignment.timeLimit).thenReturn(30L)
-    Assert.assertEquals(
+    Assertions.assertEquals(
         submission.createdAt.plusSeconds(30).truncatedTo(ChronoUnit.SECONDS),
         submission.deadline?.truncatedTo(ChronoUnit.SECONDS)
     )
@@ -67,6 +67,6 @@ class SubmissionTest {
     val deadline = Instant.now().plusSeconds(20)
     whenever(assignment.deadline).thenReturn(deadline)
     whenever(assignment.timeLimit).thenReturn(30L)
-    Assert.assertEquals(deadline, submission.deadline)
+    Assertions.assertEquals(deadline, submission.deadline)
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/entity/SubmissionTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/entity/SubmissionTest.kt
@@ -3,7 +3,8 @@ package org.codefreak.codefreak.entity
 import com.nhaarman.mockitokotlin2.whenever
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -30,20 +31,20 @@ class SubmissionTest {
 
   @Test
   fun `no deadline if neither assignment has deadline nor submission has time limit`() {
-    Assertions.assertNull(submission.deadline)
+    assertNull(submission.deadline)
   }
 
   @Test
   fun `use assignment deadline if no time limit is set`() {
     val deadline = Instant.now()
     whenever(assignment.deadline).thenReturn(deadline)
-    Assertions.assertEquals(deadline, submission.deadline)
+    assertEquals(deadline, submission.deadline)
   }
 
   @Test
   fun `use time limit if assignment has no deadline`() {
     whenever(assignment.timeLimit).thenReturn(30L)
-    Assertions.assertEquals(
+    assertEquals(
         submission.createdAt.plusSeconds(30).truncatedTo(ChronoUnit.SECONDS),
         submission.deadline?.truncatedTo(ChronoUnit.SECONDS)
     )
@@ -55,7 +56,7 @@ class SubmissionTest {
     val deadline = submission.createdAt.plusSeconds(60)
     whenever(assignment.deadline).thenReturn(deadline)
     whenever(assignment.timeLimit).thenReturn(30L)
-    Assertions.assertEquals(
+    assertEquals(
         submission.createdAt.plusSeconds(30).truncatedTo(ChronoUnit.SECONDS),
         submission.deadline?.truncatedTo(ChronoUnit.SECONDS)
     )
@@ -67,6 +68,6 @@ class SubmissionTest {
     val deadline = Instant.now().plusSeconds(20)
     whenever(assignment.deadline).thenReturn(deadline)
     whenever(assignment.timeLimit).thenReturn(30L)
-    Assertions.assertEquals(deadline, submission.deadline)
+    assertEquals(deadline, submission.deadline)
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/init/SeedDatabaseTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/init/SeedDatabaseTest.kt
@@ -2,8 +2,8 @@ package org.codefreak.codefreak.init
 
 import org.codefreak.codefreak.SpringTest
 import org.codefreak.codefreak.repository.AssignmentRepository
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
@@ -17,6 +17,6 @@ internal class SeedDatabaseTest : SpringTest() {
 
   @Test
   fun `seed database is executed in dev profile`() {
-    assertTrue(assignmentRepository.findAll().count() > 0)
+    Assertions.assertTrue(assignmentRepository.findAll().count() > 0)
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/init/SeedDatabaseTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/init/SeedDatabaseTest.kt
@@ -2,7 +2,7 @@ package org.codefreak.codefreak.init
 
 import org.codefreak.codefreak.SpringTest
 import org.codefreak.codefreak.repository.AssignmentRepository
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
@@ -17,6 +17,6 @@ internal class SeedDatabaseTest : SpringTest() {
 
   @Test
   fun `seed database is executed in dev profile`() {
-    Assertions.assertTrue(assignmentRepository.findAll().count() > 0)
+    assertTrue(assignmentRepository.findAll().count() > 0)
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/service/AssignmentAndSubmissionServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/AssignmentAndSubmissionServiceTest.kt
@@ -14,7 +14,7 @@ import org.codefreak.codefreak.repository.SubmissionRepository
 import org.codefreak.codefreak.service.file.FileService
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -65,7 +65,7 @@ class AssignmentAndSubmissionServiceTest {
   @Test
   fun `findAssignment throws for no results`() {
     `when`(assignmentRepository.findById(any())).thenReturn(Optional.empty())
-    Assertions.assertThrows(EntityNotFoundException::class.java) {
+    assertThrows(EntityNotFoundException::class.java) {
       assignmentService.findAssignment(UUID(0, 0))
     }
   }
@@ -79,7 +79,7 @@ class AssignmentAndSubmissionServiceTest {
   @Test
   fun `findSubmission throws for no results`() {
     `when`(submissionRepository.findById(any())).thenReturn(Optional.empty())
-    Assertions.assertThrows(EntityNotFoundException::class.java) {
+    assertThrows(EntityNotFoundException::class.java) {
       submissionService.findSubmission(UUID(0, 0))
     }
   }

--- a/src/test/kotlin/org/codefreak/codefreak/service/AssignmentAndSubmissionServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/AssignmentAndSubmissionServiceTest.kt
@@ -14,14 +14,15 @@ import org.codefreak.codefreak.repository.SubmissionRepository
 import org.codefreak.codefreak.service.file.FileService
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.junit.jupiter.MockitoExtension
 
-@RunWith(MockitoJUnitRunner::class)
+@ExtendWith(MockitoExtension::class)
 class AssignmentAndSubmissionServiceTest {
   private val assignment = Assignment("Assignment 1", User("user"), null)
   private val user = User("user")
@@ -36,16 +37,22 @@ class AssignmentAndSubmissionServiceTest {
 
   @Mock
   lateinit var assignmentRepository: AssignmentRepository
+
   @Mock
   lateinit var submissionRepository: SubmissionRepository
+
   @Mock
   lateinit var answerRepository: AnswerRepository
+
   @Mock
   lateinit var answerService: AnswerService
+
   @Mock
   lateinit var fileService: FileService
+
   @InjectMocks
   val assignmentService = AssignmentService()
+
   @InjectMocks
   val submissionService = SubmissionService()
 
@@ -55,10 +62,12 @@ class AssignmentAndSubmissionServiceTest {
     assertThat(assignmentService.findAssignment(UUID(0, 0)), equalTo(assignment))
   }
 
-  @Test(expected = EntityNotFoundException::class)
+  @Test
   fun `findAssignment throws for no results`() {
     `when`(assignmentRepository.findById(any())).thenReturn(Optional.empty())
-    assignmentService.findAssignment(UUID(0, 0))
+    Assertions.assertThrows(EntityNotFoundException::class.java) {
+      assignmentService.findAssignment(UUID(0, 0))
+    }
   }
 
   @Test
@@ -67,9 +76,11 @@ class AssignmentAndSubmissionServiceTest {
     assertThat(submissionService.findSubmission(UUID(0, 0)), equalTo(submission))
   }
 
-  @Test(expected = EntityNotFoundException::class)
+  @Test
   fun `findSubmission throws for no results`() {
     `when`(submissionRepository.findById(any())).thenReturn(Optional.empty())
-    submissionService.findSubmission(UUID(0, 0))
+    Assertions.assertThrows(EntityNotFoundException::class.java) {
+      submissionService.findSubmission(UUID(0, 0))
+    }
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/service/IdeServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/IdeServiceTest.kt
@@ -14,16 +14,23 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.greaterThan
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.not
-import org.junit.After
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.core.io.ClassPathResource
 
+/**
+ * The Docker library does only work properly on Linux.
+ * You should not run these tests on Windows or Mac with Docker Desktop.
+ */
+@EnabledOnOs(OS.LINUX)
 internal class IdeServiceTest : SpringTest() {
 
   @MockBean
@@ -42,14 +49,14 @@ internal class IdeServiceTest : SpringTest() {
     TarUtil.createTarFromDirectory(ClassPathResource("tasks/c-simple").file, it); it.toByteArray()
   }
 
-  @Before
+  @BeforeEach
   fun setupEntities() = super.seedDatabase()
 
-  @After
+  @AfterEach
   fun removeEntities() = super.clearDatabase()
 
-  @Before
-  @After
+  @BeforeEach
+  @AfterEach
   fun tearDown() {
     // delete all containers before and after each run
     getAllIdeContainers().parallelStream().forEach {
@@ -62,7 +69,7 @@ internal class IdeServiceTest : SpringTest() {
   fun `New IDE container is started`() {
     ideService.startIdeContainer(answer)
     val container = getIdeContainer(answer) // throws if container is not present
-    assertTrue(docker.inspectContainer(container.id()).state().running())
+    Assertions.assertTrue(docker.inspectContainer(container.id()).state().running())
   }
 
   @Test
@@ -110,7 +117,7 @@ internal class IdeServiceTest : SpringTest() {
   }
 
   @Test
-  @Ignore("Disabled until #138 is fixed")
+  @Disabled("Disabled until #138 is fixed")
   fun `idle containers are shut down automatically`() {
     ideService.startIdeContainer(answer)
     Thread.sleep(10000)

--- a/src/test/kotlin/org/codefreak/codefreak/service/IdeServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/IdeServiceTest.kt
@@ -15,7 +15,7 @@ import org.hamcrest.Matchers.greaterThan
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -69,7 +69,7 @@ internal class IdeServiceTest : SpringTest() {
   fun `New IDE container is started`() {
     ideService.startIdeContainer(answer)
     val container = getIdeContainer(answer) // throws if container is not present
-    Assertions.assertTrue(docker.inspectContainer(container.id()).state().running())
+    assertTrue(docker.inspectContainer(container.id()).state().running())
   }
 
   @Test

--- a/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
@@ -11,9 +11,9 @@ import org.codefreak.codefreak.entity.Task
 import org.codefreak.codefreak.entity.User
 import org.codefreak.codefreak.repository.EvaluationStepDefinitionRepository
 import org.codefreak.codefreak.service.file.FileService
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.mockito.InjectMocks
 import org.mockito.Mock
@@ -40,7 +40,7 @@ class TaskTarServiceTest {
   @Spy
   internal lateinit var yamlMapper: YAMLMapper
 
-  @Before
+  @BeforeEach
   fun setUp() {
     MockitoAnnotations.openMocks(this)
     yamlMapper.registerKotlinModule()
@@ -64,10 +64,10 @@ class TaskTarServiceTest {
     task.evaluationStepDefinitions.values.forEach {
       val importedDefinition = importedTask.evaluationStepDefinitions[it.key]
           ?: fail("EvaluationStep does not exist after re-import")
-      assertEquals(
-          "Step ${it.title} has an incorrect position",
+      Assertions.assertEquals(
           it.position,
-          importedDefinition.position
+          importedDefinition.position,
+        "Step ${it.title} has an incorrect position"
       )
     }
   }
@@ -81,10 +81,10 @@ class TaskTarServiceTest {
     task.evaluationStepDefinitions.values.forEach {
       val importedDefinition = importedTask.evaluationStepDefinitions[it.key]
           ?: fail("EvaluationStep does not exist after re-import")
-      assertEquals(
-          "Step ${it.title} has an incorrect active state",
+      Assertions.assertEquals(
           it.active,
-          importedDefinition.active
+          importedDefinition.active,
+        "Step ${it.title} has an incorrect active state"
       )
     }
   }

--- a/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/TaskTarServiceTest.kt
@@ -11,7 +11,7 @@ import org.codefreak.codefreak.entity.Task
 import org.codefreak.codefreak.entity.User
 import org.codefreak.codefreak.repository.EvaluationStepDefinitionRepository
 import org.codefreak.codefreak.service.file.FileService
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
@@ -64,7 +64,7 @@ class TaskTarServiceTest {
     task.evaluationStepDefinitions.values.forEach {
       val importedDefinition = importedTask.evaluationStepDefinitions[it.key]
           ?: fail("EvaluationStep does not exist after re-import")
-      Assertions.assertEquals(
+      assertEquals(
           it.position,
           importedDefinition.position,
         "Step ${it.title} has an incorrect position"
@@ -81,7 +81,7 @@ class TaskTarServiceTest {
     task.evaluationStepDefinitions.values.forEach {
       val importedDefinition = importedTask.evaluationStepDefinitions[it.key]
           ?: fail("EvaluationStep does not exist after re-import")
-      Assertions.assertEquals(
+      assertEquals(
           it.active,
           importedDefinition.active,
         "Step ${it.title} has an incorrect active state"

--- a/src/test/kotlin/org/codefreak/codefreak/service/evaluation/report/CheckstyleReportFormatParserTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/evaluation/report/CheckstyleReportFormatParserTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.codefreak.codefreak.entity.Feedback
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class CheckstyleReportFormatParserTest {
   private val parser = CheckstyleReportFormatParser(

--- a/src/test/kotlin/org/codefreak/codefreak/service/evaluation/report/JunitXmlFormatParserTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/evaluation/report/JunitXmlFormatParserTest.kt
@@ -3,7 +3,7 @@ package org.codefreak.codefreak.service.evaluation.report
 import org.codefreak.codefreak.entity.Feedback
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class JunitXmlFormatParserTest {
   @Test

--- a/src/test/kotlin/org/codefreak/codefreak/service/evaluation/report/PylintJsonReportFormatParserTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/evaluation/report/PylintJsonReportFormatParserTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.codefreak.codefreak.entity.Feedback
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class PylintJsonReportFormatParserTest {
   private val parser = PylintJsonReportFormatParser(

--- a/src/test/kotlin/org/codefreak/codefreak/service/evaluation/report/VisualStudioReportFormatParserTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/evaluation/report/VisualStudioReportFormatParserTest.kt
@@ -3,7 +3,7 @@ package org.codefreak.codefreak.service.evaluation.report
 import org.codefreak.codefreak.entity.Feedback
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class VisualStudioReportFormatParserTest {
 

--- a/src/test/kotlin/org/codefreak/codefreak/service/file/FileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/file/FileServiceTest.kt
@@ -1,8 +1,8 @@
 package org.codefreak.codefreak.service.file
 
 import java.util.UUID
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 abstract class FileServiceTest {
   abstract var collectionId: UUID
@@ -11,23 +11,25 @@ abstract class FileServiceTest {
   @Test
   fun `lists all existing files and directories`() {
     fileService.createDirectories(collectionId, setOf("some/path", "some/other/path"))
-    fileService.createFiles(collectionId,
-      setOf("file1.txt", "file2.txt", "some/file3.txt", "some/path/file4.txt", "some/other/path/file5.txt"))
+    fileService.createFiles(
+      collectionId,
+      setOf("file1.txt", "file2.txt", "some/file3.txt", "some/path/file4.txt", "some/other/path/file5.txt")
+    )
 
-    Assert.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some" })
-    Assert.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/path" })
-    Assert.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other" })
-    Assert.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other/path" })
-    Assert.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/file1.txt" })
-    Assert.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/file2.txt" })
-    Assert.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/file3.txt" })
-    Assert.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/path/file4.txt" })
-    Assert.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other/path/file5.txt" })
+    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some" })
+    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/path" })
+    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other" })
+    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other/path" })
+    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/file1.txt" })
+    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/file2.txt" })
+    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/file3.txt" })
+    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/path/file4.txt" })
+    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other/path/file5.txt" })
   }
 
   @Test
   fun `root dir does always exist with no files`() {
-    Assert.assertTrue(fileService.listFiles(collectionId, "/").count() == 0)
+    Assertions.assertTrue(fileService.listFiles(collectionId, "/").count() == 0)
   }
 
   @Test
@@ -35,9 +37,9 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt"))
 
-    Assert.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/some" })
-    Assert.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file1.txt" })
-    Assert.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file2.txt" })
+    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/some" })
+    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file1.txt" })
+    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file2.txt" })
   }
 
   @Test
@@ -45,11 +47,11 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt", "some/file3.txt"))
 
-    Assert.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/some" })
-    Assert.assertNull(fileService.listFiles(collectionId, "/").find { it.path == "/some/path" })
-    Assert.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file1.txt" })
-    Assert.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file2.txt" })
-    Assert.assertNull(fileService.listFiles(collectionId, "/").find { it.path == "/some/file3.txt" })
+    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/some" })
+    Assertions.assertNull(fileService.listFiles(collectionId, "/").find { it.path == "/some/path" })
+    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file1.txt" })
+    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file2.txt" })
+    Assertions.assertNull(fileService.listFiles(collectionId, "/").find { it.path == "/some/file3.txt" })
   }
 
   @Test
@@ -57,46 +59,52 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("some/path", "other"))
     fileService.createFiles(collectionId, setOf("file1.txt", "some/file2.txt"))
 
-    Assert.assertNull(fileService.listFiles(collectionId, "/some").find { it.path == "/other" })
-    Assert.assertNull(fileService.listFiles(collectionId, "/some").find { it.path == "/file1.txt" })
-    Assert.assertNotNull(fileService.listFiles(collectionId, "/some").find { it.path == "/some/path" })
-    Assert.assertNotNull(fileService.listFiles(collectionId, "/some").find { it.path == "/some/file2.txt" })
+    Assertions.assertNull(fileService.listFiles(collectionId, "/some").find { it.path == "/other" })
+    Assertions.assertNull(fileService.listFiles(collectionId, "/some").find { it.path == "/file1.txt" })
+    Assertions.assertNotNull(fileService.listFiles(collectionId, "/some").find { it.path == "/some/path" })
+    Assertions.assertNotNull(fileService.listFiles(collectionId, "/some").find { it.path == "/some/file2.txt" })
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `listing all files and directories in a path throws when the path does not exist`() {
-    fileService.listFiles(collectionId, "/some/path")
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.listFiles(collectionId, "/some/path")
+    }
   }
 
   @Test
   fun `creates an empty file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
   }
 
   @Test
   fun `creates multiple files`() {
     fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt", "file3.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "file2.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "file3.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file2.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file3.txt"))
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `creating a file throws on empty path name`() {
-    fileService.createFiles(collectionId, setOf(""))
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.createFiles(collectionId, setOf(""))
+    }
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `creating a file throws when path is a directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    fileService.createFiles(collectionId, setOf("some/path"))
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.createFiles(collectionId, setOf("some/path"))
+    }
   }
 
   @Test
   fun `creating a file doesn't throw when the parent directory does not exist`() {
     fileService.createFiles(collectionId, setOf("parent/file.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "parent/file.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "parent/file.txt"))
   }
 
   @Test
@@ -105,9 +113,9 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("aDirectory"))
     fileService.createFiles(collectionId, setOf("file.txt"))
 
-    Assert.assertTrue(fileService.containsFile(collectionId, "file.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "other.txt"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "other.txt"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
   }
 
   @Test
@@ -116,42 +124,44 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("aDirectory"))
     fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt"))
 
-    Assert.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "file2.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "other.txt"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file2.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "other.txt"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
   }
 
   @Test
   fun `creates an empty directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
   fun `creates a directory creates parent directories`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
   fun `creates multiple directories`() {
     fileService.createDirectories(collectionId, setOf("some/path", "some/other/path"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some/other/path"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/other/path"))
   }
 
   @Test
   fun `creating a directory ignores silently when the directory already exists`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `creating a directory throws on empty path name`() {
-    fileService.createFiles(collectionId, setOf(""))
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.createFiles(collectionId, setOf(""))
+    }
   }
 
   @Test
@@ -160,9 +170,9 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("aDirectory"))
     fileService.createDirectories(collectionId, setOf("some/path"))
 
-    Assert.assertTrue(fileService.containsFile(collectionId, "other.txt"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "other.txt"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
@@ -171,44 +181,44 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("aDirectory"))
     fileService.createDirectories(collectionId, setOf("some/path", "some/other/path"))
 
-    Assert.assertTrue(fileService.containsFile(collectionId, "other.txt"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some/other/path"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "other.txt"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/other/path"))
   }
 
   @Test
   fun `finds an existing file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
   }
 
   @Test
   fun `does not find not-existing files`() {
-    Assert.assertFalse(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "file.txt"))
   }
 
   @Test
   fun `does not find file if the path is a directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assert.assertFalse(fileService.containsFile(collectionId, "some/path"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "some/path"))
   }
 
   @Test
   fun `finds an existing directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
   fun `does not find not-existing directories`() {
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
   fun `does not find directory if the path is a file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "file.txt"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "file.txt"))
   }
 
   @Test
@@ -217,7 +227,7 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("file.txt"))
 
-    Assert.assertFalse(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "file.txt"))
   }
 
   @Test
@@ -226,13 +236,15 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("file1.txt", "file2.txt"))
 
-    Assert.assertFalse(fileService.containsFile(collectionId, "file1.txt"))
-    Assert.assertFalse(fileService.containsFile(collectionId, "file2.txt"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "file1.txt"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "file2.txt"))
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `deleting a file throws when path does not exist`() {
-    fileService.deleteFiles(collectionId, setOf("file.txt"))
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.deleteFiles(collectionId, setOf("file.txt"))
+    }
   }
 
   @Test
@@ -241,11 +253,11 @@ abstract class FileServiceTest {
 
     try {
       fileService.deleteFiles(collectionId, setOf("file1.txt", "file2.txt"))
-      Assert.fail() // An IllegalArgumentException should be thrown
+      Assertions.fail() // An IllegalArgumentException should be thrown
     } catch (e: IllegalArgumentException) {
     }
 
-    Assert.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
   }
 
   @Test
@@ -256,9 +268,9 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("file.txt"))
 
-    Assert.assertFalse(fileService.containsFile(collectionId, "file.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "DO_NOT_DELETE.txt"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "DO_NOT_DELETE.txt"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
@@ -267,7 +279,7 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("some/path"))
 
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
@@ -276,8 +288,8 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("some/path", "some/other/path"))
 
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/other/path"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/other/path"))
   }
 
   @Test
@@ -286,10 +298,10 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("some/path", "some/other/path", "file1.txt", "file2.txt"))
 
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/other/path"))
-    Assert.assertFalse(fileService.containsFile(collectionId, "file1.txt"))
-    Assert.assertFalse(fileService.containsFile(collectionId, "file2.txt"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/other/path"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "file1.txt"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "file2.txt"))
   }
 
   @Test
@@ -300,9 +312,9 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("some/path"))
 
-    Assert.assertTrue(fileService.containsFile(collectionId, "file.txt"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "DO_NOT_DELETE"))
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "DO_NOT_DELETE"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
@@ -319,10 +331,10 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf(directoryToDelete))
 
-    Assert.assertFalse(fileService.containsDirectory(collectionId, directoryToDelete))
-    Assert.assertFalse(fileService.containsFile(collectionId, fileToRecursivelyDelete))
-    Assert.assertFalse(fileService.containsDirectory(collectionId, directoryToRecursivelyDelete))
-    Assert.assertTrue(fileService.containsFile(collectionId, fileToBeUnaffected))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, directoryToDelete))
+    Assertions.assertFalse(fileService.containsFile(collectionId, fileToRecursivelyDelete))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, directoryToRecursivelyDelete))
+    Assertions.assertTrue(fileService.containsFile(collectionId, fileToBeUnaffected))
   }
 
   @Test
@@ -334,8 +346,8 @@ abstract class FileServiceTest {
       it.write(contents)
     }
 
-    Assert.assertTrue(fileService.containsFile(collectionId, "file.txt"))
-    Assert.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), contents))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), contents))
   }
 
   private fun equals(a: ByteArray, b: ByteArray): Boolean {
@@ -352,20 +364,24 @@ abstract class FileServiceTest {
     return true
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `writing file contents throws for directories`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
 
-    fileService.writeFile(collectionId, "some/path").use {
-      it.write(byteArrayOf(42))
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.writeFile(collectionId, "some/path").use {
+        it.write(byteArrayOf(42))
+      }
     }
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `writing file contents throws when path is a directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    fileService.writeFile(collectionId, "some/path").use {
-      it.write(byteArrayOf(42))
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.writeFile(collectionId, "some/path").use {
+        it.write(byteArrayOf(42))
+      }
     }
   }
 
@@ -375,8 +391,8 @@ abstract class FileServiceTest {
       it.write(byteArrayOf(42))
     }
 
-    Assert.assertTrue(fileService.containsFile(collectionId, "file.txt"))
-    Assert.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), byteArrayOf(42)))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), byteArrayOf(42)))
   }
 
   @Test
@@ -393,26 +409,29 @@ abstract class FileServiceTest {
       it.write(newContent)
     }
 
-    Assert.assertFalse(equals(fileService.readFile(collectionId, "file.txt").readBytes(), oldContent))
-    Assert.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), newContent))
+    Assertions.assertFalse(equals(fileService.readFile(collectionId, "file.txt").readBytes(), oldContent))
+    Assertions.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), newContent))
   }
 
   @Test
   fun `reads an existing empty file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
-    Assert.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), byteArrayOf()))
+    Assertions.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), byteArrayOf()))
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `reading file contents throws for directories`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-
-    fileService.readFile(collectionId, "some/path")
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.readFile(collectionId, "some/path")
+    }
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `reading file contents throws if path does not exist`() {
-    fileService.readFile(collectionId, "file.txt")
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.readFile(collectionId, "file.txt")
+    }
   }
 
   @Test
@@ -421,8 +440,8 @@ abstract class FileServiceTest {
 
     fileService.renameFile(collectionId, "file.txt", "new.txt")
 
-    Assert.assertFalse(fileService.containsFile(collectionId, "file.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "new.txt"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "new.txt"))
   }
 
   @Test
@@ -432,15 +451,17 @@ abstract class FileServiceTest {
 
     fileService.moveFile(collectionId, setOf("file1.txt", "file2.txt"), "some/path")
 
-    Assert.assertFalse(fileService.containsFile(collectionId, "file1.txt"))
-    Assert.assertFalse(fileService.containsFile(collectionId, "file2.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "some/path/file1.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "some/path/file2.txt"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "file1.txt"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "file2.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "some/path/file1.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "some/path/file2.txt"))
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `moving a file throws when source path does not exist`() {
-    fileService.moveFile(collectionId, setOf("file.txt"), "new.txt")
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.moveFile(collectionId, setOf("file.txt"), "new.txt")
+    }
   }
 
   @Test
@@ -450,27 +471,31 @@ abstract class FileServiceTest {
 
     try {
       fileService.moveFile(collectionId, setOf("file1.txt", "file2.txt"), "new")
-      Assert.fail() // An IllegalArgumentException should be thrown
+      Assertions.fail() // An IllegalArgumentException should be thrown
     } catch (e: IllegalArgumentException) {
     }
 
-    Assert.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
-    Assert.assertFalse(fileService.containsFile(collectionId, "new/file1.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "new/file1.txt"))
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `moving a file throws when target file path already exists`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
     fileService.createFiles(collectionId, setOf("new.txt"))
 
-    fileService.moveFile(collectionId, setOf("file.txt"), "new.txt")
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.moveFile(collectionId, setOf("file.txt"), "new.txt")
+    }
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `moving multiple files throws when target file path does not exist`() {
     fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt"))
 
-    fileService.moveFile(collectionId, setOf("file1.txt", "file2.txt"), "new")
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.moveFile(collectionId, setOf("file1.txt", "file2.txt"), "new")
+    }
   }
 
   @Test
@@ -483,7 +508,7 @@ abstract class FileServiceTest {
 
     fileService.renameFile(collectionId, "file.txt", "new.txt")
 
-    Assert.assertTrue(equals(contents, fileService.readFile(collectionId, "new.txt").readBytes()))
+    Assertions.assertTrue(equals(contents, fileService.readFile(collectionId, "new.txt").readBytes()))
   }
 
   @Test
@@ -492,8 +517,8 @@ abstract class FileServiceTest {
 
     fileService.renameFile(collectionId, "some/path", "new")
 
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "new"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "new"))
   }
 
   @Test
@@ -502,18 +527,20 @@ abstract class FileServiceTest {
 
     fileService.moveFile(collectionId, setOf("some/path", "some/other"), "new")
 
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/other"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "new/path"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "new/other"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/other"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "new/path"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "new/other"))
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `moving a directory throws when source directory is moved to itself`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createDirectories(collectionId, setOf("some/path/inner"))
 
-    fileService.moveFile(collectionId, setOf("some/path"), "some/path/inner")
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
+      fileService.moveFile(collectionId, setOf("some/path"), "some/path/inner")
+    }
   }
 
   @Test
@@ -533,23 +560,23 @@ abstract class FileServiceTest {
 
     fileService.renameFile(collectionId, "some/path", "new")
 
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
-    Assert.assertFalse(fileService.containsDirectory(collectionId, "some/path/inner"))
-    Assert.assertFalse(fileService.containsFile(collectionId, "some/path/inner/file.txt"))
-    Assert.assertFalse(fileService.containsFile(collectionId, "some/path/file.txt"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "new"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "new/inner"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "new/inner/file.txt"))
-    Assert.assertTrue(equals(fileService.readFile(collectionId, "new/inner/file.txt").readBytes(), byteArrayOf(42)))
-    Assert.assertTrue(fileService.containsFile(collectionId, "new/file.txt"))
-    Assert.assertTrue(equals(fileService.readFile(collectionId, "new/file.txt").readBytes(), innerFile2Contents))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path/inner"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "some/path/inner/file.txt"))
+    Assertions.assertFalse(fileService.containsFile(collectionId, "some/path/file.txt"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "new"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "new/inner"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "new/inner/file.txt"))
+    Assertions.assertTrue(equals(fileService.readFile(collectionId, "new/inner/file.txt").readBytes(), byteArrayOf(42)))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "new/file.txt"))
+    Assertions.assertTrue(equals(fileService.readFile(collectionId, "new/file.txt").readBytes(), innerFile2Contents))
   }
 
   @Test
   fun `moving from child to parent directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.moveFile(collectionId, setOf("some/path"), "/")
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "path"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "path"))
   }
 
   @Test
@@ -557,7 +584,7 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("some"))
     fileService.createFiles(collectionId, setOf("some/file.txt"))
     fileService.renameFile(collectionId, "some/file.txt", "some/file.txt")
-    Assert.assertTrue(fileService.containsFile(collectionId, "some/file.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "some/file.txt"))
   }
 
   @Test
@@ -565,12 +592,12 @@ abstract class FileServiceTest {
     fileService.createFiles(collectionId, setOf("file.txt"))
     fileService.createFiles(collectionId, setOf("file2.txt"))
     fileService.moveFile(collectionId, setOf("file.txt", "file2.txt"), "/")
-    Assert.assertTrue(fileService.containsFile(collectionId, "file.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "file2.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "file2.txt"))
 
     fileService.createDirectories(collectionId, setOf("subdir"))
     fileService.createFiles(collectionId, setOf("subdir/file.txt"))
     fileService.moveFile(collectionId, setOf("subdir/file.txt"), "subdir")
-    Assert.assertTrue(fileService.containsFile(collectionId, "subdir/file.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "subdir/file.txt"))
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/service/file/FileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/file/FileServiceTest.kt
@@ -251,10 +251,8 @@ abstract class FileServiceTest {
   fun `deleting multiple files does not delete any file when one of the files does not exist`() {
     fileService.createFiles(collectionId, setOf("file1.txt"))
 
-    try {
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.deleteFiles(collectionId, setOf("file1.txt", "file2.txt"))
-      Assertions.fail() // An IllegalArgumentException should be thrown
-    } catch (e: IllegalArgumentException) {
     }
 
     Assertions.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
@@ -469,10 +467,8 @@ abstract class FileServiceTest {
     fileService.createFiles(collectionId, setOf("file1.txt"))
     fileService.createDirectories(collectionId, setOf("new"))
 
-    try {
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.moveFile(collectionId, setOf("file1.txt", "file2.txt"), "new")
-      Assertions.fail() // An IllegalArgumentException should be thrown
-    } catch (e: IllegalArgumentException) {
     }
 
     Assertions.assertTrue(fileService.containsFile(collectionId, "file1.txt"))

--- a/src/test/kotlin/org/codefreak/codefreak/service/file/FileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/file/FileServiceTest.kt
@@ -1,7 +1,11 @@
 package org.codefreak.codefreak.service.file
 
 import java.util.UUID
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 abstract class FileServiceTest {
@@ -16,20 +20,20 @@ abstract class FileServiceTest {
       setOf("file1.txt", "file2.txt", "some/file3.txt", "some/path/file4.txt", "some/other/path/file5.txt")
     )
 
-    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some" })
-    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/path" })
-    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other" })
-    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other/path" })
-    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/file1.txt" })
-    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/file2.txt" })
-    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/file3.txt" })
-    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/path/file4.txt" })
-    Assertions.assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other/path/file5.txt" })
+    assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some" })
+    assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/path" })
+    assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other" })
+    assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other/path" })
+    assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/file1.txt" })
+    assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/file2.txt" })
+    assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/file3.txt" })
+    assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/path/file4.txt" })
+    assertNotNull(fileService.walkFileTree(collectionId).find { it.path == "/some/other/path/file5.txt" })
   }
 
   @Test
   fun `root dir does always exist with no files`() {
-    Assertions.assertTrue(fileService.listFiles(collectionId, "/").count() == 0)
+    assertTrue(fileService.listFiles(collectionId, "/").count() == 0)
   }
 
   @Test
@@ -37,9 +41,9 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt"))
 
-    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/some" })
-    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file1.txt" })
-    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file2.txt" })
+    assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/some" })
+    assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file1.txt" })
+    assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file2.txt" })
   }
 
   @Test
@@ -47,11 +51,11 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt", "some/file3.txt"))
 
-    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/some" })
-    Assertions.assertNull(fileService.listFiles(collectionId, "/").find { it.path == "/some/path" })
-    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file1.txt" })
-    Assertions.assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file2.txt" })
-    Assertions.assertNull(fileService.listFiles(collectionId, "/").find { it.path == "/some/file3.txt" })
+    assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/some" })
+    assertNull(fileService.listFiles(collectionId, "/").find { it.path == "/some/path" })
+    assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file1.txt" })
+    assertNotNull(fileService.listFiles(collectionId, "/").find { it.path == "/file2.txt" })
+    assertNull(fileService.listFiles(collectionId, "/").find { it.path == "/some/file3.txt" })
   }
 
   @Test
@@ -59,15 +63,15 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("some/path", "other"))
     fileService.createFiles(collectionId, setOf("file1.txt", "some/file2.txt"))
 
-    Assertions.assertNull(fileService.listFiles(collectionId, "/some").find { it.path == "/other" })
-    Assertions.assertNull(fileService.listFiles(collectionId, "/some").find { it.path == "/file1.txt" })
-    Assertions.assertNotNull(fileService.listFiles(collectionId, "/some").find { it.path == "/some/path" })
-    Assertions.assertNotNull(fileService.listFiles(collectionId, "/some").find { it.path == "/some/file2.txt" })
+    assertNull(fileService.listFiles(collectionId, "/some").find { it.path == "/other" })
+    assertNull(fileService.listFiles(collectionId, "/some").find { it.path == "/file1.txt" })
+    assertNotNull(fileService.listFiles(collectionId, "/some").find { it.path == "/some/path" })
+    assertNotNull(fileService.listFiles(collectionId, "/some").find { it.path == "/some/file2.txt" })
   }
 
   @Test
   fun `listing all files and directories in a path throws when the path does not exist`() {
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.listFiles(collectionId, "/some/path")
     }
   }
@@ -75,20 +79,20 @@ abstract class FileServiceTest {
   @Test
   fun `creates an empty file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file.txt"))
   }
 
   @Test
   fun `creates multiple files`() {
     fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt", "file3.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file2.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file3.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file1.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file2.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file3.txt"))
   }
 
   @Test
   fun `creating a file throws on empty path name`() {
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf(""))
     }
   }
@@ -96,7 +100,7 @@ abstract class FileServiceTest {
   @Test
   fun `creating a file throws when path is a directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf("some/path"))
     }
   }
@@ -104,7 +108,7 @@ abstract class FileServiceTest {
   @Test
   fun `creating a file doesn't throw when the parent directory does not exist`() {
     fileService.createFiles(collectionId, setOf("parent/file.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "parent/file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "parent/file.txt"))
   }
 
   @Test
@@ -113,9 +117,9 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("aDirectory"))
     fileService.createFiles(collectionId, setOf("file.txt"))
 
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "other.txt"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
+    assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "other.txt"))
+    assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
   }
 
   @Test
@@ -124,42 +128,42 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("aDirectory"))
     fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt"))
 
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file2.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "other.txt"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
+    assertTrue(fileService.containsFile(collectionId, "file1.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file2.txt"))
+    assertTrue(fileService.containsFile(collectionId, "other.txt"))
+    assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
   }
 
   @Test
   fun `creates an empty directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
   fun `creates a directory creates parent directories`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
   fun `creates multiple directories`() {
     fileService.createDirectories(collectionId, setOf("some/path", "some/other/path"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/other/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/other/path"))
   }
 
   @Test
   fun `creating a directory ignores silently when the directory already exists`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
   fun `creating a directory throws on empty path name`() {
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf(""))
     }
   }
@@ -170,9 +174,9 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("aDirectory"))
     fileService.createDirectories(collectionId, setOf("some/path"))
 
-    Assertions.assertTrue(fileService.containsFile(collectionId, "other.txt"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsFile(collectionId, "other.txt"))
+    assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
@@ -181,44 +185,44 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("aDirectory"))
     fileService.createDirectories(collectionId, setOf("some/path", "some/other/path"))
 
-    Assertions.assertTrue(fileService.containsFile(collectionId, "other.txt"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/other/path"))
+    assertTrue(fileService.containsFile(collectionId, "other.txt"))
+    assertTrue(fileService.containsDirectory(collectionId, "aDirectory"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/other/path"))
   }
 
   @Test
   fun `finds an existing file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file.txt"))
   }
 
   @Test
   fun `does not find not-existing files`() {
-    Assertions.assertFalse(fileService.containsFile(collectionId, "file.txt"))
+    assertFalse(fileService.containsFile(collectionId, "file.txt"))
   }
 
   @Test
   fun `does not find file if the path is a directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assertions.assertFalse(fileService.containsFile(collectionId, "some/path"))
+    assertFalse(fileService.containsFile(collectionId, "some/path"))
   }
 
   @Test
   fun `finds an existing directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
   fun `does not find not-existing directories`() {
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
   fun `does not find directory if the path is a file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "file.txt"))
+    assertFalse(fileService.containsDirectory(collectionId, "file.txt"))
   }
 
   @Test
@@ -227,7 +231,7 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("file.txt"))
 
-    Assertions.assertFalse(fileService.containsFile(collectionId, "file.txt"))
+    assertFalse(fileService.containsFile(collectionId, "file.txt"))
   }
 
   @Test
@@ -236,13 +240,13 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("file1.txt", "file2.txt"))
 
-    Assertions.assertFalse(fileService.containsFile(collectionId, "file1.txt"))
-    Assertions.assertFalse(fileService.containsFile(collectionId, "file2.txt"))
+    assertFalse(fileService.containsFile(collectionId, "file1.txt"))
+    assertFalse(fileService.containsFile(collectionId, "file2.txt"))
   }
 
   @Test
   fun `deleting a file throws when path does not exist`() {
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.deleteFiles(collectionId, setOf("file.txt"))
     }
   }
@@ -251,11 +255,11 @@ abstract class FileServiceTest {
   fun `deleting multiple files does not delete any file when one of the files does not exist`() {
     fileService.createFiles(collectionId, setOf("file1.txt"))
 
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.deleteFiles(collectionId, setOf("file1.txt", "file2.txt"))
     }
 
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file1.txt"))
   }
 
   @Test
@@ -266,9 +270,9 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("file.txt"))
 
-    Assertions.assertFalse(fileService.containsFile(collectionId, "file.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "DO_NOT_DELETE.txt"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "some/path"))
+    assertFalse(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "DO_NOT_DELETE.txt"))
+    assertTrue(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
@@ -277,7 +281,7 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("some/path"))
 
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
@@ -286,8 +290,8 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("some/path", "some/other/path"))
 
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/other/path"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/other/path"))
   }
 
   @Test
@@ -296,10 +300,10 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("some/path", "some/other/path", "file1.txt", "file2.txt"))
 
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/other/path"))
-    Assertions.assertFalse(fileService.containsFile(collectionId, "file1.txt"))
-    Assertions.assertFalse(fileService.containsFile(collectionId, "file2.txt"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/other/path"))
+    assertFalse(fileService.containsFile(collectionId, "file1.txt"))
+    assertFalse(fileService.containsFile(collectionId, "file2.txt"))
   }
 
   @Test
@@ -310,9 +314,9 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf("some/path"))
 
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "DO_NOT_DELETE"))
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(fileService.containsDirectory(collectionId, "DO_NOT_DELETE"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
   }
 
   @Test
@@ -329,10 +333,10 @@ abstract class FileServiceTest {
 
     fileService.deleteFiles(collectionId, setOf(directoryToDelete))
 
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, directoryToDelete))
-    Assertions.assertFalse(fileService.containsFile(collectionId, fileToRecursivelyDelete))
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, directoryToRecursivelyDelete))
-    Assertions.assertTrue(fileService.containsFile(collectionId, fileToBeUnaffected))
+    assertFalse(fileService.containsDirectory(collectionId, directoryToDelete))
+    assertFalse(fileService.containsFile(collectionId, fileToRecursivelyDelete))
+    assertFalse(fileService.containsDirectory(collectionId, directoryToRecursivelyDelete))
+    assertTrue(fileService.containsFile(collectionId, fileToBeUnaffected))
   }
 
   @Test
@@ -344,8 +348,8 @@ abstract class FileServiceTest {
       it.write(contents)
     }
 
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
-    Assertions.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), contents))
+    assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), contents))
   }
 
   private fun equals(a: ByteArray, b: ByteArray): Boolean {
@@ -366,7 +370,7 @@ abstract class FileServiceTest {
   fun `writing file contents throws for directories`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
 
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.writeFile(collectionId, "some/path").use {
         it.write(byteArrayOf(42))
       }
@@ -376,7 +380,7 @@ abstract class FileServiceTest {
   @Test
   fun `writing file contents throws when path is a directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.writeFile(collectionId, "some/path").use {
         it.write(byteArrayOf(42))
       }
@@ -389,8 +393,8 @@ abstract class FileServiceTest {
       it.write(byteArrayOf(42))
     }
 
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
-    Assertions.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), byteArrayOf(42)))
+    assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), byteArrayOf(42)))
   }
 
   @Test
@@ -407,27 +411,27 @@ abstract class FileServiceTest {
       it.write(newContent)
     }
 
-    Assertions.assertFalse(equals(fileService.readFile(collectionId, "file.txt").readBytes(), oldContent))
-    Assertions.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), newContent))
+    assertFalse(equals(fileService.readFile(collectionId, "file.txt").readBytes(), oldContent))
+    assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), newContent))
   }
 
   @Test
   fun `reads an existing empty file`() {
     fileService.createFiles(collectionId, setOf("file.txt"))
-    Assertions.assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), byteArrayOf()))
+    assertTrue(equals(fileService.readFile(collectionId, "file.txt").readBytes(), byteArrayOf()))
   }
 
   @Test
   fun `reading file contents throws for directories`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.readFile(collectionId, "some/path")
     }
   }
 
   @Test
   fun `reading file contents throws if path does not exist`() {
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.readFile(collectionId, "file.txt")
     }
   }
@@ -438,8 +442,8 @@ abstract class FileServiceTest {
 
     fileService.renameFile(collectionId, "file.txt", "new.txt")
 
-    Assertions.assertFalse(fileService.containsFile(collectionId, "file.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "new.txt"))
+    assertFalse(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "new.txt"))
   }
 
   @Test
@@ -449,15 +453,15 @@ abstract class FileServiceTest {
 
     fileService.moveFile(collectionId, setOf("file1.txt", "file2.txt"), "some/path")
 
-    Assertions.assertFalse(fileService.containsFile(collectionId, "file1.txt"))
-    Assertions.assertFalse(fileService.containsFile(collectionId, "file2.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "some/path/file1.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "some/path/file2.txt"))
+    assertFalse(fileService.containsFile(collectionId, "file1.txt"))
+    assertFalse(fileService.containsFile(collectionId, "file2.txt"))
+    assertTrue(fileService.containsFile(collectionId, "some/path/file1.txt"))
+    assertTrue(fileService.containsFile(collectionId, "some/path/file2.txt"))
   }
 
   @Test
   fun `moving a file throws when source path does not exist`() {
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.moveFile(collectionId, setOf("file.txt"), "new.txt")
     }
   }
@@ -467,12 +471,12 @@ abstract class FileServiceTest {
     fileService.createFiles(collectionId, setOf("file1.txt"))
     fileService.createDirectories(collectionId, setOf("new"))
 
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.moveFile(collectionId, setOf("file1.txt", "file2.txt"), "new")
     }
 
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file1.txt"))
-    Assertions.assertFalse(fileService.containsFile(collectionId, "new/file1.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file1.txt"))
+    assertFalse(fileService.containsFile(collectionId, "new/file1.txt"))
   }
 
   @Test
@@ -480,7 +484,7 @@ abstract class FileServiceTest {
     fileService.createFiles(collectionId, setOf("file.txt"))
     fileService.createFiles(collectionId, setOf("new.txt"))
 
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.moveFile(collectionId, setOf("file.txt"), "new.txt")
     }
   }
@@ -489,7 +493,7 @@ abstract class FileServiceTest {
   fun `moving multiple files throws when target file path does not exist`() {
     fileService.createFiles(collectionId, setOf("file1.txt", "file2.txt"))
 
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.moveFile(collectionId, setOf("file1.txt", "file2.txt"), "new")
     }
   }
@@ -504,7 +508,7 @@ abstract class FileServiceTest {
 
     fileService.renameFile(collectionId, "file.txt", "new.txt")
 
-    Assertions.assertTrue(equals(contents, fileService.readFile(collectionId, "new.txt").readBytes()))
+    assertTrue(equals(contents, fileService.readFile(collectionId, "new.txt").readBytes()))
   }
 
   @Test
@@ -513,8 +517,8 @@ abstract class FileServiceTest {
 
     fileService.renameFile(collectionId, "some/path", "new")
 
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "new"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "new"))
   }
 
   @Test
@@ -523,10 +527,10 @@ abstract class FileServiceTest {
 
     fileService.moveFile(collectionId, setOf("some/path", "some/other"), "new")
 
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/other"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "new/path"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "new/other"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/other"))
+    assertTrue(fileService.containsDirectory(collectionId, "new/path"))
+    assertTrue(fileService.containsDirectory(collectionId, "new/other"))
   }
 
   @Test
@@ -534,7 +538,7 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.createDirectories(collectionId, setOf("some/path/inner"))
 
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.moveFile(collectionId, setOf("some/path"), "some/path/inner")
     }
   }
@@ -556,23 +560,23 @@ abstract class FileServiceTest {
 
     fileService.renameFile(collectionId, "some/path", "new")
 
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path"))
-    Assertions.assertFalse(fileService.containsDirectory(collectionId, "some/path/inner"))
-    Assertions.assertFalse(fileService.containsFile(collectionId, "some/path/inner/file.txt"))
-    Assertions.assertFalse(fileService.containsFile(collectionId, "some/path/file.txt"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "new"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "new/inner"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "new/inner/file.txt"))
-    Assertions.assertTrue(equals(fileService.readFile(collectionId, "new/inner/file.txt").readBytes(), byteArrayOf(42)))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "new/file.txt"))
-    Assertions.assertTrue(equals(fileService.readFile(collectionId, "new/file.txt").readBytes(), innerFile2Contents))
+    assertFalse(fileService.containsDirectory(collectionId, "some/path"))
+    assertFalse(fileService.containsDirectory(collectionId, "some/path/inner"))
+    assertFalse(fileService.containsFile(collectionId, "some/path/inner/file.txt"))
+    assertFalse(fileService.containsFile(collectionId, "some/path/file.txt"))
+    assertTrue(fileService.containsDirectory(collectionId, "new"))
+    assertTrue(fileService.containsDirectory(collectionId, "new/inner"))
+    assertTrue(fileService.containsFile(collectionId, "new/inner/file.txt"))
+    assertTrue(equals(fileService.readFile(collectionId, "new/inner/file.txt").readBytes(), byteArrayOf(42)))
+    assertTrue(fileService.containsFile(collectionId, "new/file.txt"))
+    assertTrue(equals(fileService.readFile(collectionId, "new/file.txt").readBytes(), innerFile2Contents))
   }
 
   @Test
   fun `moving from child to parent directory`() {
     fileService.createDirectories(collectionId, setOf("some/path"))
     fileService.moveFile(collectionId, setOf("some/path"), "/")
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "path"))
+    assertTrue(fileService.containsDirectory(collectionId, "path"))
   }
 
   @Test
@@ -580,7 +584,7 @@ abstract class FileServiceTest {
     fileService.createDirectories(collectionId, setOf("some"))
     fileService.createFiles(collectionId, setOf("some/file.txt"))
     fileService.renameFile(collectionId, "some/file.txt", "some/file.txt")
-    Assertions.assertTrue(fileService.containsFile(collectionId, "some/file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "some/file.txt"))
   }
 
   @Test
@@ -588,12 +592,12 @@ abstract class FileServiceTest {
     fileService.createFiles(collectionId, setOf("file.txt"))
     fileService.createFiles(collectionId, setOf("file2.txt"))
     fileService.moveFile(collectionId, setOf("file.txt", "file2.txt"), "/")
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "file2.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "file2.txt"))
 
     fileService.createDirectories(collectionId, setOf("subdir"))
     fileService.createFiles(collectionId, setOf("subdir/file.txt"))
     fileService.moveFile(collectionId, setOf("subdir/file.txt"), "subdir")
-    Assertions.assertTrue(fileService.containsFile(collectionId, "subdir/file.txt"))
+    assertTrue(fileService.containsFile(collectionId, "subdir/file.txt"))
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/service/file/FileSystemFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/file/FileSystemFileServiceTest.kt
@@ -2,17 +2,17 @@ package org.codefreak.codefreak.service.file
 
 import java.util.UUID
 import org.codefreak.codefreak.config.AppConfiguration
-import org.junit.After
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 
 class FileSystemFileServiceTest : FileServiceTest() {
   override var collectionId: UUID = UUID(0, 0)
   override lateinit var fileService: FileService
 
-  @Before
+  @BeforeEach
   fun init() {
     val config = Mockito.mock(AppConfiguration::class.java)
 
@@ -27,7 +27,7 @@ class FileSystemFileServiceTest : FileServiceTest() {
     fileService = FileSystemFileService(config)
   }
 
-  @After
+  @AfterEach
   fun tearDown() {
     // Cleanup created files
     fileService.deleteCollection(collectionId)
@@ -35,79 +35,59 @@ class FileSystemFileServiceTest : FileServiceTest() {
 
   @Test
   fun `cannot read files outside of the collection`() {
-    try {
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.readFile(collectionId, "/../foo.txt")
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
-
-    try {
+    }
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.readFile(collectionId, "foo/../../bar.txt")
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
-
-    try {
+    }
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.readFile(collectionId, "foo/../../../../../etc/passwd")
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
+    }
   }
 
   @Test
   fun `files trying to escape the collection path are still created inside the collection`() {
     fileService.createFiles(collectionId, setOf("/../foo.txt", "foo/../../bar.txt"))
 
-    Assert.assertTrue(fileService.containsFile(collectionId, "/foo.txt"))
-    Assert.assertTrue(fileService.containsFile(collectionId, "/bar.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "/foo.txt"))
+    Assertions.assertTrue(fileService.containsFile(collectionId, "/bar.txt"))
   }
 
   @Test
   fun `directories trying to escape the collection path are still created inside the collection`() {
     fileService.createDirectories(collectionId, setOf("/../foo", "foo/../../bar", "foo/../../../../../etc/passwd"))
 
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "/foo"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "/bar"))
-    Assert.assertTrue(fileService.containsDirectory(collectionId, "/etc/passwd"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "/foo"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "/bar"))
+    Assertions.assertTrue(fileService.containsDirectory(collectionId, "/etc/passwd"))
   }
 
   @Test
   fun `cannot create blacklisted files and directories`() {
-    try {
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf(".git"))
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
-
-    try {
+    }
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf(".git/foo"))
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
-
-    try {
+    }
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf(".gitignore"))
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
-
-    try {
+    }
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf(".gitattributes"))
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
-
-    try {
+    }
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.createDirectories(collectionId, setOf(".git"))
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
-
-    try {
+    }
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.createDirectories(collectionId, setOf(".git/foo"))
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
-
-    try {
+    }
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.createDirectories(collectionId, setOf(".gitignore"))
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
-
-    try {
+    }
+    Assertions.assertThrows(IllegalArgumentException::class.java) {
       fileService.createDirectories(collectionId, setOf(".gitattributes"))
-      Assert.fail()
-    } catch (e: IllegalArgumentException) {}
+    }
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/service/file/FileSystemFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/file/FileSystemFileServiceTest.kt
@@ -3,7 +3,8 @@ package org.codefreak.codefreak.service.file
 import java.util.UUID
 import org.codefreak.codefreak.config.AppConfiguration
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
@@ -35,13 +36,13 @@ class FileSystemFileServiceTest : FileServiceTest() {
 
   @Test
   fun `cannot read files outside of the collection`() {
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.readFile(collectionId, "/../foo.txt")
     }
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.readFile(collectionId, "foo/../../bar.txt")
     }
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.readFile(collectionId, "foo/../../../../../etc/passwd")
     }
   }
@@ -50,43 +51,43 @@ class FileSystemFileServiceTest : FileServiceTest() {
   fun `files trying to escape the collection path are still created inside the collection`() {
     fileService.createFiles(collectionId, setOf("/../foo.txt", "foo/../../bar.txt"))
 
-    Assertions.assertTrue(fileService.containsFile(collectionId, "/foo.txt"))
-    Assertions.assertTrue(fileService.containsFile(collectionId, "/bar.txt"))
+    assertTrue(fileService.containsFile(collectionId, "/foo.txt"))
+    assertTrue(fileService.containsFile(collectionId, "/bar.txt"))
   }
 
   @Test
   fun `directories trying to escape the collection path are still created inside the collection`() {
     fileService.createDirectories(collectionId, setOf("/../foo", "foo/../../bar", "foo/../../../../../etc/passwd"))
 
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "/foo"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "/bar"))
-    Assertions.assertTrue(fileService.containsDirectory(collectionId, "/etc/passwd"))
+    assertTrue(fileService.containsDirectory(collectionId, "/foo"))
+    assertTrue(fileService.containsDirectory(collectionId, "/bar"))
+    assertTrue(fileService.containsDirectory(collectionId, "/etc/passwd"))
   }
 
   @Test
   fun `cannot create blacklisted files and directories`() {
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf(".git"))
     }
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf(".git/foo"))
     }
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf(".gitignore"))
     }
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createFiles(collectionId, setOf(".gitattributes"))
     }
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createDirectories(collectionId, setOf(".git"))
     }
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createDirectories(collectionId, setOf(".git/foo"))
     }
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createDirectories(collectionId, setOf(".gitignore"))
     }
-    Assertions.assertThrows(IllegalArgumentException::class.java) {
+    assertThrows(IllegalArgumentException::class.java) {
       fileService.createDirectories(collectionId, setOf(".gitattributes"))
     }
   }

--- a/src/test/kotlin/org/codefreak/codefreak/service/file/JpaFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/file/JpaFileServiceTest.kt
@@ -5,7 +5,7 @@ import java.util.Optional
 import java.util.UUID
 import org.codefreak.codefreak.entity.FileCollection
 import org.codefreak.codefreak.repository.FileCollectionRepository
-import org.junit.Before
+import org.junit.jupiter.api.BeforeEach
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito
@@ -20,7 +20,7 @@ class JpaFileServiceTest : FileServiceTest() {
   @Mock
   lateinit var fileCollectionRepository: FileCollectionRepository
 
-  @Before
+  @BeforeEach
   fun init() {
     MockitoAnnotations.openMocks(this)
 

--- a/src/test/kotlin/org/codefreak/codefreak/util/FileUtilTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/util/FileUtilTest.kt
@@ -1,7 +1,7 @@
 package org.codefreak.codefreak.util
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 class FileUtilTest {
   @Test
@@ -22,7 +22,7 @@ class FileUtilTest {
       "../.." to "",
       ".././foo" to "foo"
     ).forEach {
-      Assert.assertEquals(it.value, FileUtil.sanitizeName(it.key))
+      Assertions.assertEquals(it.value, FileUtil.sanitizeName(it.key))
     }
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/util/FileUtilTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/util/FileUtilTest.kt
@@ -1,6 +1,6 @@
 package org.codefreak.codefreak.util
 
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class FileUtilTest {
@@ -22,7 +22,7 @@ class FileUtilTest {
       "../.." to "",
       ".././foo" to "foo"
     ).forEach {
-      Assertions.assertEquals(it.value, FileUtil.sanitizeName(it.key))
+      assertEquals(it.value, FileUtil.sanitizeName(it.key))
     }
   }
 }

--- a/src/test/kotlin/org/codefreak/codefreak/util/NetUtilTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/util/NetUtilTest.kt
@@ -6,7 +6,7 @@ import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.hasProperty
 import org.hamcrest.Matchers.hasSize
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 internal class NetUtilTest {
   @Test

--- a/src/test/kotlin/org/codefreak/codefreak/util/TarUtilTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/util/TarUtilTest.kt
@@ -9,7 +9,7 @@ import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.notNullValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.springframework.core.io.ClassPathResource
 import org.springframework.mock.web.MockPart
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,5 +1,7 @@
 codefreak:
   instanceId: test
+  scheduling:
+    enable: false
   ide:
     idle-check-rate: 1000
     idle-shutdown-threshold: 5000


### PR DESCRIPTION
## :scroll: Description
We had a weird mix of JUnit 4 and 5 tests. This will drop JUnit 4 entirely and thus prevents accidental imports of it.
Additionally this will:
1. Disable spring scheduling during tests
2. Enable tests using Docker only on Linux (The Spotify Docker lib does only work properly with native Docker)

## :link: Related Issues
* Fixes # (issue)

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
