### PR TITLE
Fix normalizing a path starting with two slashes

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/graphql/api/FileApi.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/graphql/api/FileApi.kt
@@ -20,6 +20,7 @@ import org.codefreak.codefreak.service.file.FileContentService
 import org.codefreak.codefreak.service.file.FileMetaData
 import org.codefreak.codefreak.service.file.FileService
 import org.codefreak.codefreak.util.exhaustive
+import org.codefreak.codefreak.util.withTrailingSlash
 import org.springframework.stereotype.Component
 
 @GraphQLName("FileType")
@@ -126,7 +127,7 @@ class FileMutation : BaseResolver(), Mutation {
     val fileService = serviceAccess.getService(FileService::class)
     files.forEach { file ->
       val filename = file.submittedFileName ?: "upload-${Instant.now()}-${file.name}"
-      val filePath = "$dir/$filename"
+      val filePath = "${dir.withTrailingSlash()}$filename"
       fileService.writeFile(fileContext.id, filePath).use {
         IOUtils.copy(file.inputStream, it)
       }

--- a/src/main/kotlin/org/codefreak/codefreak/util/FileUtil.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/FileUtil.kt
@@ -39,7 +39,10 @@ object FileUtil {
    * /a/../../b/c will return b/c
    */
   fun normalizePath(vararg name: String): String {
-    var concated = name.joinToString(File.separator)
+    // Trim slashes at the beginning because
+    // * a single slash would be trimmed in the end nonetheless
+    // * two slashes might be interpreted as a prefix by the FilenameUtils, which is not what we want
+    var concated = FilenameUtils.separatorsToSystem(name.joinToString(File.separator)).trimStart(File.separatorChar)
     // FilenameUtils.normalize returns null in case it has no parent directory left to work with
     // so "/../foo" will return null. We trick this by prepending fake directories to the original path
     // until we get a valid path from FilenameUtils.normalize.

--- a/src/test/kotlin/org/codefreak/codefreak/util/FileUtilTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/util/FileUtilTest.kt
@@ -15,6 +15,10 @@ class FileUtilTest {
       "foo" to "foo",
       // keep leading/trailing spaces as they are valid in filenames
       " foo " to " foo ",
+      "/foo" to "foo",
+      "//foo" to "foo",
+      "\\\\foo" to "foo",
+      ".//foo" to "foo",
       // resulting path will contain the correct directory separator
       "foo/bar" to "foo" + File.separatorChar + "bar",
       ".foo" to ".foo",


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
When a path starting with two slashes is normalized `FilenameUtils` interpreted those as a prefix which caused prepended `a/` directories to those paths.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [x] I have added tests that prove my fix is effective or that my feature works
