### PR TITLE
Add Websocket connection count to actuator metrics

### DIFF
--- a/cloud-companion/build.gradle.kts
+++ b/cloud-companion/build.gradle.kts
@@ -32,6 +32,7 @@ repositories {
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-actuator")
+  implementation("org.springframework.boot:spring-boot-starter-aop")
   implementation("org.springframework.experimental:graphql-spring-boot-starter:1.0.0-SNAPSHOT")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
   implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")

--- a/cloud-companion/src/main/kotlin/org/codefreak/cloud/companion/WebsocketConnectionMetricAdvice.kt
+++ b/cloud-companion/src/main/kotlin/org/codefreak/cloud/companion/WebsocketConnectionMetricAdvice.kt
@@ -1,0 +1,60 @@
+package org.codefreak.cloud.companion
+
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.BaseUnits
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.max
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+/**
+ * Advice that counts the number of open websocket connections by wrapping around the {WebSocketHandler#handle} method.
+ * The counter is increased every time the returned Mono is subscribed to and decreased when it is unsubscribed.
+ */
+@Aspect
+@Component
+class WebsocketConnectionMetricAdvice(
+  meterRegistry: MeterRegistry
+) {
+    companion object {
+        private val log = LoggerFactory.getLogger(WebsocketConnectionMetricAdvice::class.java)
+    }
+
+    private val connectionCounter = AtomicInteger()
+
+    init {
+        Gauge.builder("http.websocket.connections", connectionCounter) { it.get().toDouble() }
+            .description("Number of active websocket connections")
+            .baseUnit(BaseUnits.CONNECTIONS)
+            .register(meterRegistry)
+    }
+
+    @Around(value = "execution(* org.springframework.web.reactive.socket.WebSocketHandler.handle(..))")
+    fun onHandle(pjp: ProceedingJoinPoint): Mono<*> {
+        val producer = pjp.proceed(pjp.args) as Mono<*>
+        return producer.doOnSubscribe {
+            registerNewConnection()
+        }.doFinally {
+            unregisterConnection()
+        }
+    }
+
+    private fun registerNewConnection() {
+        val newCount = connectionCounter.incrementAndGet()
+        log.debug("Client connected! New connection count: $newCount")
+    }
+
+    private fun unregisterConnection() {
+        var newCount: Int
+        do {
+            val currentCount = connectionCounter.get()
+            newCount = max(0, currentCount - 1)
+        } while (!connectionCounter.compareAndSet(currentCount, newCount))
+        log.debug("Client disconnected! New connection count: $newCount")
+    }
+}

--- a/cloud-companion/src/main/resources/application.yml
+++ b/cloud-companion/src/main/resources/application.yml
@@ -15,6 +15,8 @@ management:
       exposure:
         include: health,prometheus,metrics
   endpoint:
+    metrics:
+      enabled: true
     health:
       enabled: true
       # Make probes also work outside of kubernetes

--- a/cloud-companion/src/test/kotlin/org/codefreak/cloud/companion/WebsocketConnectionMetricAdviceTest.kt
+++ b/cloud-companion/src/test/kotlin/org/codefreak/cloud/companion/WebsocketConnectionMetricAdviceTest.kt
@@ -1,0 +1,40 @@
+package org.codefreak.cloud.companion
+
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.aspectj.lang.ProceedingJoinPoint
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.any
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+internal class WebsocketConnectionMetricAdviceTest {
+
+    private lateinit var connectionMetricAdvice: WebsocketConnectionMetricAdvice
+    private lateinit var gauge: Gauge
+
+    @BeforeEach
+    fun beforeEach() {
+        val meterRegistry = SimpleMeterRegistry()
+        connectionMetricAdvice = WebsocketConnectionMetricAdvice(meterRegistry)
+        gauge = meterRegistry.get("http.websocket.connections").gauge()
+    }
+
+    @Test
+    fun testCountsUpAndDown() {
+        val pjp = Mockito.mock(ProceedingJoinPoint::class.java)
+        `when`(pjp.proceed(any())).thenReturn(Mono.just("1"))
+        val wrappedMono = connectionMetricAdvice.onHandle(pjp)
+
+        assertThat(gauge.value(), `is`(.0))
+        StepVerifier.create(wrappedMono)
+            .assertNext { assertThat(gauge.value(), `is`(1.0)) }
+            .verifyComplete()
+        assertThat(gauge.value(), `is`(.0))
+    }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
This adds a connection count metric to the companion in preparation for shutting down idle workspaces.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] I updated the `CHANGELOG.md`
- [x] I have added tests that prove my fix is effective or that my feature works
