### PR TITLE
Use GitHub container registry for publishing images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Fetch Tags correctly
         run: git fetch --force --tags
 
-      - name: Cache gradle dependencies
+      - name: Restore Gradle cache
         uses: actions/cache@v2
         with:
           path: |
@@ -39,7 +39,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Cache node modules
+      - name: Restore npm cache
         uses: actions/cache@v2
         with:
           path: |
@@ -66,11 +66,40 @@ jobs:
         with:
           working-directory: client
           install: false
-          start: docker run -d -e CODEFREAK_REVERSE_PROXY_URL="http://$(docker network inspect bridge -f '{{ (index .IPAM.Config 0).Gateway }}')" -v /var/run/docker.sock:/var/run/docker.sock -p8080:8080 --name=cfreak-cypress cfreak/codefreak
+          start: docker run -d -e CODEFREAK_REVERSE_PROXY_URL="http://$(docker network inspect bridge -f '{{ (index .IPAM.Config 0).Gateway }}')" -v /var/run/docker.sock:/var/run/docker.sock -p8080:8080 --name=cfreak-cypress ghcr.io/codefreak/codefreak
           config-file: cypress/cypress-ci.json
           wait-on: 'http://localhost:8080'
           wait-on-timeout: 180
           headless: true
+
+      - name: Install docker-ci-deploy
+        if: matrix.deploy && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
+        run: |
+          pip3 install --upgrade pip
+          pip3 install docker-ci-deploy
+
+      - name: Authenticate to GitHub Docker Registry
+        if: matrix.deploy && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
+        run: |
+          docker logout
+          # "Username" can be anything as we are authenticating via the default workflow access token!
+          # See https://github.com/actions/starter-workflows/issues/66
+          echo ${{ github.token }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Deploy master branch as latest
+        if: matrix.deploy && github.ref == 'refs/heads/master'
+        run: |
+          python -m docker_ci_deploy --tag canary -- ghcr.io/codefreak/codefreak
+          python -m docker_ci_deploy --tag canary -- ghcr.io/codefreak/codefreak-cloud-companion
+
+      # ${GITHUB_REF/refs\/tags\//} returns the tag name from 'refs/tags/TAG_NAME'
+      # The following will only work with tags following semantic versioning!
+      - name: Deploy tags
+        if: matrix.deploy && startsWith(github.ref, 'refs/tags')
+        run: |
+          export TAG_VERSION="${GITHUB_REF/refs\/tags\//}"
+          python -m docker_ci_deploy --version-latest --version "$TAG_VERSION" --version-semver ghcr.io/codefreak/codefreak
+          python -m docker_ci_deploy --version-latest --version "$TAG_VERSION" --version-semver ghcr.io/codefreak/codefreak-cloud-companion
 
       - name: Prepare cache on Windows
         if: runner.os == 'Windows'
@@ -84,20 +113,3 @@ jobs:
         run: |
           rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
           rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-
-      - name: Before Deploy
-        if: matrix.deploy && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
-        run: |
-          pip3 install --upgrade pip
-          pip3 install docker-ci-deploy
-          docker logout
-          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
-
-      - name: Deploy master branch as latest
-        if: matrix.deploy && github.ref == 'refs/heads/master'
-        run: python -m docker_ci_deploy --tag canary -- cfreak/codefreak
-
-      # ${GITHUB_REF/refs\/tags\//} returns the tag name from 'refs/tags/TAG_NAME'
-      - name: Deploy tags
-        if: matrix.deploy && startsWith(github.ref, 'refs/tags')
-        run: python -m docker_ci_deploy --version-latest --version ${GITHUB_REF/refs\/tags\//} --version-semver cfreak/codefreak

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 <h1 align="center">Code FREAK</h1>
 
 [![CI](https://github.com/codefreak/codefreak/actions/workflows/main.yml/badge.svg)](https://github.com/codefreak/codefreak/actions/workflows/main.yml)
-[![Docker Image Version](https://img.shields.io/docker/v/cfreak/codefreak?sort=semver)](https://hub.docker.com/r/cfreak/codefreak)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-informational.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Join Discord Server](https://img.shields.io/discord/748856997105107025?color=7289da&label=discord&logo=discord&logoColor=ffffff)](https://discord.gg/HYDQEDt)
 
@@ -24,7 +23,9 @@ Code FREAK (Code Feedback, Review & Evaluation Kit) is an online programming pla
 
 ## Installation
 
-We currently only support installation via Docker. The image name is [`cfreak/codefreak`](https://hub.docker.com/r/cfreak/codefreak). Check out its [tags](https://hub.docker.com/r/cfreak/codefreak?tab=tags) for the latest version.
+We currently only support installation via Docker.
+The image name is [`ghcr.io/codefreak/codefreak`](https://github.com/codefreak/codefreak/pkgs/container/codefreak).
+Check out its [tags](https://github.com/codefreak/codefreak/pkgs/container/codefreak/versions) for the latest version.
 
 ### Try with Docker 🐋
 
@@ -36,7 +37,7 @@ docker run -it --rm \
     -e SPRING_PROFILES_ACTIVE=dev \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -p 8080:8080 \
-    cfreak/codefreak:canary
+    ghcr.io/codefreak/codefreak:canary
 ```
 
 The UI is accessible at http://localhost:8080.
@@ -50,7 +51,7 @@ This will use you local Docker daemon for evaluation and IDE instances.
 
 There are two major image versions on Docker Hub: `latest` and `canary`. `latest` always points to the latest stable release and `canary` is basically a snapshot release based on the `master` branch from GitHub.
 
-Our image tags follow semantic versioning. For example the tag `cfreak/codefreak:4` will always reference the latest v4 release.
+Our image tags follow semantic versioning. For example the tag `ghcr.io/codefreak/codefreak:4` will always reference the latest v4 release.
 
 ### Deployment & Configuration
 

--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,7 @@ task deployFrontend(type: Copy) {
 
 jib {
   to {
-    image = "cfreak/codefreak"
+    image = "ghcr.io/codefreak/codefreak"
   }
   container {
     mainClass = springBoot.mainClassName
@@ -214,6 +214,9 @@ jib {
     ]
     volumes = [
       "/var/lib/codefreak"
+    ]
+    labels = [
+      "org.opencontainers.image.source": "https://github.com/codefreak/codefreak"
     ]
   }
 }

--- a/cloud-companion/build.gradle.kts
+++ b/cloud-companion/build.gradle.kts
@@ -89,7 +89,7 @@ jib {
     volumes = listOf(
       "/code"
     )
-    labels.put("org.opencontainers.image.source", "https://github.com/codefreak/codefreak-cloud-companion")
+    labels.put("org.opencontainers.image.source", "https://github.com/codefreak/codefreak")
   }
   pluginExtensions {
     pluginExtension {

--- a/docs/modules/for-admins/pages/installation.adoc
+++ b/docs/modules/for-admins/pages/installation.adoc
@@ -55,7 +55,7 @@ The following is a example production configuration for Docker Compose that runs
 version: "3.7"
 services:
   app:
-    image: "cfreak/codefreak"
+    image: "ghcr.io/codefreak/codefreak"
     restart: "on-failure:10"
     ports:
       # you might want to use a reverse proxy that passes the traffic to Code FREAK

--- a/docs/modules/for-developers/pages/development.adoc
+++ b/docs/modules/for-developers/pages/development.adoc
@@ -48,7 +48,7 @@ See the configuration below to improve the default settings.
 == Building Code FREAK
 
 Build Code FREAK by using `./gradlew jibDockerBuild`.
-This will generate the Docker image `cfreak/codefreak` on your local machine.
+This will generate the Docker image `ghcr.io/codefreak/codefreak` and `ghcr.io/codefreak/codefreak-cloud-companion` on your local machine.
 
 == Configuration
 


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
I would like to use the GH package registry for future work. Docker Hub's Auto-Build feature stopped working for free accounts and we are already using GitHub for CI, so why not use the package repostiory as well which is free for public projects.
