### PR TITLE
Build and deploy companion all-in-one image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,21 @@ jobs:
         shell: bash
         run: ./gradlew check
 
-      - name: Build Docker image
-        shell: bash
+      - name: Build Server and Companion Images
         # Import of jib image into Windows Docker is currently not working on CI
         if: runner.os != 'Windows'
-        run: ./gradlew jibDockerBuild -x bootJar
+        # This will build the "server" image and the (minimal) companion image.
+        run: ./gradlew jibDockerBuild
+
+      # Build the companion aio (all-in-one) image only when on master or tags
+      # Because the image is huge (~15GB) we need to free up some space on GH Actions before we can build the image.
+      - name: Build Companion All-In-One Image
+        if: (runner.os != 'Windows') && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          ./gradlew :cloud-companion:jibDockerBuild -P companion-build-aio
 
       - name: Run end-to-end tests
         # Not possible due to missing image (see step above)
@@ -80,7 +90,7 @@ jobs:
           pip3 install --upgrade pip
           pip3 install docker-ci-deploy
 
-      - name: Authenticate to GitHub Docker Registry
+      - name: Authenticate to GitHub Container Registry
         if: matrix.deploy && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
         run: |
           docker logout
@@ -88,20 +98,32 @@ jobs:
           # See https://github.com/actions/starter-workflows/issues/66
           echo ${{ github.token }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Deploy master branch as latest
+      - name: Deploy master branch as canary
         if: matrix.deploy && github.ref == 'refs/heads/master'
         run: |
           python -m docker_ci_deploy --tag canary -- ghcr.io/codefreak/codefreak
-          python -m docker_ci_deploy --tag canary -- ghcr.io/codefreak/codefreak-cloud-companion
+          python -m docker_ci_deploy --tag minimal-canary -- ghcr.io/codefreak/codefreak-cloud-companion:minimal
+          python -m docker_ci_deploy --tag aio-canary -- ghcr.io/codefreak/codefreak-cloud-companion:aio
 
       # ${GITHUB_REF/refs\/tags\//} returns the tag name from 'refs/tags/TAG_NAME'
       # The following will only work with tags following semantic versioning!
+      # It will publish the following images:
+      # - ghcr.io/codefreak/codefreak as
+      #   - ghcr.io/codefreak/codefreak:latest
+      #   - ghcr.io/codefreak/codefreak:X.X.X (+ semver tags for minor and major)
+      # - ghcr.io/codefreak/codefreak-cloud-companion:minimal as
+      #   - ghcr.io/codefreak/codefreak-cloud-companion:minimal
+      #   - ghcr.io/codefreak/codefreak-cloud-companion:X.X.X-minimal (+ semver tags for minor and major)
+      # - ghcr.io/codefreak/codefreak-cloud-companion:aio as
+      #   - ghcr.io/codefreak/codefreak-cloud-companion:aio
+      #   - ghcr.io/codefreak/codefreak-cloud-companion:X.X.X-aio (+ semver tags for minor and major)
       - name: Deploy tags
         if: matrix.deploy && startsWith(github.ref, 'refs/tags')
         run: |
           export TAG_VERSION="${GITHUB_REF/refs\/tags\//}"
           python -m docker_ci_deploy --version-latest --version "$TAG_VERSION" --version-semver ghcr.io/codefreak/codefreak
-          python -m docker_ci_deploy --version-latest --version "$TAG_VERSION" --version-semver ghcr.io/codefreak/codefreak-cloud-companion
+          python -m docker_ci_deploy --version-latest --version "$TAG_VERSION" --version-semver ghcr.io/codefreak/codefreak-cloud-companion:minimal
+          python -m docker_ci_deploy --version-latest --version "$TAG_VERSION" --version-semver ghcr.io/codefreak/codefreak-cloud-companion:aio
 
       - name: Prepare cache on Windows
         if: runner.os == 'Windows'

--- a/cloud-companion/build.gradle.kts
+++ b/cloud-companion/build.gradle.kts
@@ -81,7 +81,7 @@ tasks.withType<Test> {
 
 jib {
   from {
-    //image = "replco/polygott:c82c08a720ba1fd537d4fba17eed883ab87c0fd7"
+    image = "docker.io/replco/polygott:9180d8b24b181125577e98a8f5418781e863e852"
   }
   to {
     image = "ghcr.io/codefreak/codefreak-cloud-companion"

--- a/cloud-companion/build.gradle.kts
+++ b/cloud-companion/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.getCurrentOperatingSystem
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   id("org.springframework.boot")
@@ -58,14 +57,14 @@ dependencies {
   testImplementation("io.projectreactor:reactor-test")
 }
 
-tasks.withType<KotlinCompile> {
+tasks.compileKotlin {
   kotlinOptions {
     freeCompilerArgs = listOf("-Xjsr305=strict")
     jvmTarget = "1.8"
   }
 }
 
-tasks.withType<Test> {
+tasks.test {
 
   // The tests are somehow broken on Windows. Especially the file-related
   // tests tend to fail deleting files. Maybe somewhere are leaking file
@@ -80,11 +79,33 @@ tasks.withType<Test> {
 }
 
 jib {
-  from {
-    image = "docker.io/replco/polygott:9180d8b24b181125577e98a8f5418781e863e852"
+  // Creating the full all-in-one image containing all compilers is hidden behind a build flag because
+  // the final image will be HUGE (~15GB). By default, this will build a minimal image based on
+  // adoptopenjdk:8-jre-hotspot. You can enable the all-in-one build by passing the
+  // "companion-build-aio" flag to gradle:
+  // ./gradlew :cloud-companion:jib[DockerBuild] -P companion-build-aio
+  val buildAio = project.hasProperty("companion-build-aio")
+  if (buildAio) {
+    project.logger.info("Build companion all-in-one image. Build might take while...")
   }
+
+  from {
+    image = if (buildAio) {
+      "docker.io/replco/polygott:9180d8b24b181125577e98a8f5418781e863e852"
+    } else {
+        // adoptopenjdk:8-jre-hotspot
+      "docker.io/library/adoptopenjdk@sha256:f89b4c0ee78145a575df40017b12003d86ed877c4a68bd063f7ca0221ff8643b"
+    }
+  }
+
   to {
     image = "ghcr.io/codefreak/codefreak-cloud-companion"
+
+    tags = if (buildAio) {
+      setOf("aio")
+    } else {
+      setOf("minimal")
+    }
   }
   container {
     volumes = listOf(


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
This will build a companion image containing all kinds of compilers and tools. The image will only be build when CI runs on master because the compilation takes a lot of time (and diskspace).
There will always be a `minimal` companion image based on openjdk 8 which will also be deployed as `latest`.
