### PR TITLE
Allow to specify additional ENV variables for process

### DIFF
--- a/cloud-companion/src/main/kotlin/org/codefreak/cloud/companion/graphql/api/ProcessController.kt
+++ b/cloud-companion/src/main/kotlin/org/codefreak/cloud/companion/graphql/api/ProcessController.kt
@@ -21,9 +21,18 @@ class ProcessController {
   private lateinit var processManager: ProcessManager
 
   @MutationMapping
-  fun startProcess(@Argument cmd: List<String>): Mono<ProcessModel> {
+  fun startProcess(@Argument cmd: List<String>, @Argument env: List<String>?): Mono<ProcessModel> {
+    val additionalEnv = env?.map { it.split("=", limit = 2) }
+      ?.filter { it.isNotEmpty() }
+      ?.associate {
+        if (it.size == 1) {
+          Pair(it[0], "")
+        } else {
+          Pair(it[0], it[1])
+        }
+      }
     return Mono.fromCallable {
-      ProcessModel(processManager.createProcess(cmd))
+      ProcessModel(processManager.createProcess(cmd, additionalEnv ?: emptyMap()))
     }.subscribeOn(Schedulers.boundedElastic())
   }
 

--- a/cloud-companion/src/main/resources/graphql/schema.graphqls
+++ b/cloud-companion/src/main/resources/graphql/schema.graphqls
@@ -27,7 +27,7 @@ type FileSystemEvent {
 type Mutation {
   killProcess(id: UUID!): Int!
   resizeProcess(cols: Int!, id: UUID!, rows: Int!): Boolean!
-  startProcess(cmd: [String!]!): Process!
+  startProcess(cmd: [String!]!, env: [String!]): Process!
 }
 
 type Process {


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
This allows to specify additional environment variables like `FOO=bar` when starting a process in the companion.
