### PR TITLE
Fix entity link to tasks in the task list

### DIFF
--- a/client/src/components/TaskList.tsx
+++ b/client/src/components/TaskList.tsx
@@ -87,7 +87,7 @@ const renderTask = (props: RenderProps) => (task: Task) => {
             <Markdown>{task.body}</Markdown>
           </CropContainer>
         ) : null}
-        <EntityLink to={task} sub={task.answer ? '/answer' : undefined}>
+        <EntityLink to={task}>
           <Button icon={<FolderOpenOutlined />} type="primary">
             Details
           </Button>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
This button was still referencing the old `/answer` tab. Now it just opens the task page.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
